### PR TITLE
closed #63 FilterクラスのrowPassFilter関数の戻り値をfloatからdoubleに変更した

### DIFF
--- a/src/module/Filter.cpp
+++ b/src/module/Filter.cpp
@@ -6,7 +6,9 @@
 #include "Filter.h"
 
 template <typename T>
-Filter<T>::Filter() : preValue_(0) {}
+Filter<T>::Filter() : preValue_(0)
+{
+}
 
 /**
  *  [Filter::lowPassFilter]
@@ -16,12 +18,12 @@ Filter<T>::Filter() : preValue_(0) {}
  *  @return       [フィルター後の値]
  */
 template <typename T>
-float Filter<T>::lowPassFilter(T value, float rate)
+double Filter<T>::lowPassFilter(T value, double rate)
 {
   // 前回値の初期化
   if(preValue_ == 0) {
     preValue_ = value;
-    return static_cast<float>(value);
+    return static_cast<double>(value);
   }
 
   return preValue_ * rate + value * (1 - rate);

--- a/src/module/Filter.h
+++ b/src/module/Filter.h
@@ -13,7 +13,7 @@ class Filter {
 
  public:
   Filter();
-  float lowPassFilter(T value, float rate = 0.9f);
+  double lowPassFilter(T value, double rate = 0.9);
 };
 
 #endif

--- a/test/FilterTest.cpp
+++ b/test/FilterTest.cpp
@@ -14,7 +14,7 @@ namespace etrobocon2019_test {
     int sensor = 24;
 
     // 前回のセンサー値がない場合は、入力値をそのまま返す
-    ASSERT_EQ(static_cast<float>(sensor), filter.lowPassFilter(sensor));
+    ASSERT_EQ(static_cast<double>(sensor), filter.lowPassFilter(sensor));
   }
 
   TEST(Filter, lowPassFilterTest_filter)
@@ -27,7 +27,7 @@ namespace etrobocon2019_test {
 
     // 期待出力の計算
     int sensor = 77;
-    float expected = preSensor * 0.9 + sensor * 0.1;
+    double expected = preSensor * 0.9 + sensor * 0.1;
     // フィルターをかける
     ASSERT_EQ(expected, filter.lowPassFilter(sensor));
   }
@@ -38,13 +38,13 @@ namespace etrobocon2019_test {
     float preSensor = 2.3;
 
     // フィルターの初期化
-    ASSERT_FLOAT_EQ(preSensor, filter.lowPassFilter(preSensor));
+    ASSERT_DOUBLE_EQ(preSensor, filter.lowPassFilter(preSensor));
 
     // 期待出力の計算
     float sensor = 4.4;
-    float expected = preSensor * 0.9 + sensor * 0.1;
+    double expected = preSensor * 0.9 + sensor * 0.1;
     // フィルターをかける
-    ASSERT_FLOAT_EQ(expected, filter.lowPassFilter(sensor));
+    ASSERT_DOUBLE_EQ(expected, filter.lowPassFilter(sensor));
   }
 
   TEST(Filter, lowPassFilterTest_double)
@@ -53,12 +53,12 @@ namespace etrobocon2019_test {
     double preSensor = 2.3;
 
     // フィルターの初期化
-    ASSERT_DOUBLE_EQ(static_cast<float>(preSensor), filter.lowPassFilter(preSensor));
+    ASSERT_DOUBLE_EQ(preSensor, filter.lowPassFilter(preSensor));
 
     // 期待出力の計算
     double sensor = 4.4;
-    float expected = preSensor * 0.9 + sensor * 0.1;
+    double expected = preSensor * 0.9 + sensor * 0.1;
     // フィルターをかける
     ASSERT_DOUBLE_EQ(expected, filter.lowPassFilter(sensor));
   }
-}
+}  // namespace etrobocon2019_test


### PR DESCRIPTION
### 変更点
rowPassFilter関数の戻り値をfloatからdoubleに変更した

### 実機テストの結果（実機テストが必要な場合）
 - 例: 10回走行させた平均値を書く
 - 例: 誤差率 [%] を書く
 - 例: 前回の手法との差を書く

#### 誤差率の計算式
誤差率 = （「測定値」 - 「理論値」） / 「理論値」 * 100