### PR TITLE
closed #95 Pidクラスにゲイン値を設定する関数を作成する

### DIFF
--- a/src/module/Pid.cpp
+++ b/src/module/Pid.cpp
@@ -53,11 +53,14 @@ double Pid::control(double value, double delta)
  * @param Kp_ [Pゲイン]
  * @param Ki_ [Iゲイン]
  * @param Kd_ [Dゲイン]
+ * @param 設定した目標値
  */
-void Pid::setParameter(double target_, double Kp_, double Ki_, double Kd_)
+const double Pid::setParameter(double target_, double Kp_, double Ki_, double Kd_)
 {
   target = target_;
   setPidGain(Kp_, Ki_, Kd_);
+
+  return target;
 }
 
 /**
@@ -65,10 +68,12 @@ void Pid::setParameter(double target_, double Kp_, double Ki_, double Kd_)
  * @param Kp_ [Pゲイン]
  * @param Ki_ [Iゲイン]
  * @param Kd_ [Dゲイン]
+ * @param PidGain構造体の参照
  */
-void Pid::setPidGain(double Kp_, double Ki_, double Kd_)
+const PidGain& Pid::setPidGain(double Kp_, double Ki_, double Kd_)
 {
   gain.setPidGain(Kp_, Ki_, Kd_);
+  return gain;
 }
 
 /**

--- a/src/module/Pid.cpp
+++ b/src/module/Pid.cpp
@@ -12,6 +12,13 @@ Pid::Pid(double target_, double Kp_, double Ki_, double Kd_)
 {
 }
 
+void PidGain::setPidGain(double Kp_, double Ki_, double Kd_)
+{
+  Kp = Kp_;
+  Ki = Ki_;
+  Kd = Kd_;
+}
+
 /**
  *  [Pid::control]
  *  @param  value [現在値]
@@ -38,6 +45,30 @@ double Pid::control(double value, double delta)
   double d = gain.Kd * diff;
 
   return limit(p + i + d);
+}
+
+/**
+ * @brief 目標値とPIDゲインの設定をする関数
+ * @param target_ [設定する目標値]
+ * @param Kp_ [Pゲイン]
+ * @param Ki_ [Iゲイン]
+ * @param Kd_ [Dゲイン]
+ */
+void Pid::setParameter(double target_, double Kp_, double Ki_, double Kd_)
+{
+  target = target_;
+  setPidGain(Kp_, Ki_, Kd_);
+}
+
+/**
+ * @brief PIDゲインの設定をする関数
+ * @param Kp_ [Pゲイン]
+ * @param Ki_ [Iゲイン]
+ * @param Kd_ [Dゲイン]
+ */
+void Pid::setPidGain(double Kp_, double Ki_, double Kd_)
+{
+  gain.setPidGain(Kp_, Ki_, Kd_);
 }
 
 /**

--- a/src/module/Pid.h
+++ b/src/module/Pid.h
@@ -25,8 +25,8 @@ class Pid {
  public:
   Pid(double target_, double Kp_, double Ki_ = 0.0, double Kd_ = 0.0);
   double control(double value, double delta = 0.004);
-  void setParameter(double target_, double Kp_, double Ki_ = 0.0, double Kd_ = 0.0);
-  void setPidGain(double Kp_, double Ki_ = 0.0, double Kd_ = 0.0);
+  const double setParameter(double target_, double Kp_, double Ki_ = 0.0, double Kd_ = 0.0);
+  const PidGain& setPidGain(double Kp_, double Ki_ = 0.0, double Kd_ = 0.0);
   double limit(double value);
 };
 

--- a/src/module/Pid.h
+++ b/src/module/Pid.h
@@ -23,8 +23,10 @@ class Pid {
   double preError;
 
  public:
-  Pid(double target_, double Kp_, double Ki_ = 0.0f, double Kd_ = 0.0f);
+  Pid(double target_, double Kp_, double Ki_ = 0.0, double Kd_ = 0.0);
   double control(double value, double delta = 0.004);
+  void setParameter(double target_, double Kp_, double Ki_ = 0.0, double Kd_ = 0.0);
+  void setPidGain(double Kp_, double Ki_ = 0.0, double Kd_ = 0.0);
   double limit(double value);
 };
 

--- a/test/PidTest.cpp
+++ b/test/PidTest.cpp
@@ -7,6 +7,18 @@
 #include <gtest/gtest.h>
 
 namespace etrobocon2019_test {
+  TEST(PidGain, construct) { PidGain gain(0.6, 0.2, 0.3); }
+
+  TEST(PidGain, setPidGain)
+  {
+    PidGain gain(0.6, 0.2, 0.3);
+    gain.setPidGain(0.8, 0.01, 0.2);
+
+    ASSERT_DOUBLE_EQ(0.8, gain.Kp);
+    ASSERT_DOUBLE_EQ(0.01, gain.Ki);
+    ASSERT_DOUBLE_EQ(0.2, gain.Kd);
+  }
+
   TEST(Pid, Pid_init)
   {
     // P制御を行なうオブジェクトの作成
@@ -68,5 +80,21 @@ namespace etrobocon2019_test {
   {
     Pid pid(80, 0.6);
     ASSERT_FLOAT_EQ(12.3, pid.limit(12.3));
+  }
+
+  TEST(Pid, setParameter)
+  {
+    Pid pid(80, 0.2);
+    const double target = pid.setParameter(60, 0.3, 0.4, 0.6);
+    ASSERT_DOUBLE_EQ(60.0, target);
+  }
+
+  TEST(Pid, setPidGain)
+  {
+    Pid pid(80, 0.2);
+    const PidGain& gain = pid.setPidGain(0.6, 0.3, 0.5);
+    ASSERT_DOUBLE_EQ(0.6, gain.Kp);
+    ASSERT_DOUBLE_EQ(0.3, gain.Ki);
+    ASSERT_DOUBLE_EQ(0.5, gain.Kd);
   }
 }  // namespace etrobocon2019_test


### PR DESCRIPTION
### 変更点
Pidクラスにセッターを追加しました。

### 実機テストの結果（実機テストが必要な場合）
 - 例: 10回走行させた平均値を書く
 - 例: 誤差率 [%] を書く
 - 例: 前回の手法との差を書く

#### 誤差率の計算式
誤差率 = （「測定値」 - 「理論値」） / 「理論値」 * 100