### PR TITLE
closed #121 Loggerクラスのコンストラクターでファイル名を指定できるようにする

### DIFF
--- a/src/module/Logger.cpp
+++ b/src/module/Logger.cpp
@@ -5,14 +5,11 @@
  */
 #include "Logger.h"
 
-LogFile::TemporaryObject::TemporaryObject(FILE* fp_, bool linefeed_)
-  : fp(fp_), isHead(true), linefeed(linefeed_)
-{
-}
+LogFile::TemporaryObject::TemporaryObject(FILE* fp_) : fp(fp_), isHead(true) {}
 
 LogFile::TemporaryObject::~TemporaryObject()
 {
-  if(linefeed) std::fputc('\n', fp);
+  std::fputc('\n', fp);
 }
 
 void LogFile::TemporaryObject::putDelimiter()
@@ -26,8 +23,7 @@ void LogFile::TemporaryObject::putDelimiter()
   std::fputc(',', fp);
 }
 
-Logger::Logger(const std::string& fileName, const char* mode, bool linefeed_)
-  : fp(nullptr), linefeed(linefeed_)
+Logger::Logger(const std::string& fileName, const char* mode)
 {
   fp = std::fopen(getFileName(fileName).c_str(), mode);
   assert(fp != nullptr);

--- a/src/module/Logger.cpp
+++ b/src/module/Logger.cpp
@@ -23,9 +23,9 @@ void LogFile::TemporaryObject::putDelimiter()
   std::fputc(',', fp);
 }
 
-Logger::Logger(const char* mode)
+Logger::Logger(const std::string& fileName, const char* mode)
 {
-  fp = std::fopen(getFileName().c_str(), mode);
+  fp = std::fopen(getFileName(fileName).c_str(), mode);
   assert(fp != nullptr);
 }
 
@@ -34,11 +34,9 @@ Logger::~Logger()
   std::fclose(fp);
 }
 
-std::string Logger::getFileName()
+const std::string& Logger::getFileName(const std::string& fileName) const
 {
-  // TODO とりあえずログファイル名は、「log」としておく
-  // ユニークな名前にするためには、例えば現在時刻を取得する必要があるが、取得しようとするとmutexエラーが起きる
-  return "log.csv";
+  return fileName;
 }
 
 void Logger::write(const char* format, ...)

--- a/src/module/Logger.cpp
+++ b/src/module/Logger.cpp
@@ -5,11 +5,14 @@
  */
 #include "Logger.h"
 
-LogFile::TemporaryObject::TemporaryObject(FILE* fp_) : fp(fp_), isHead(true) {}
+LogFile::TemporaryObject::TemporaryObject(FILE* fp_, bool linefeed_)
+  : fp(fp_), isHead(true), linefeed(linefeed_)
+{
+}
 
 LogFile::TemporaryObject::~TemporaryObject()
 {
-  std::fputc('\n', fp);
+  if(linefeed) std::fputc('\n', fp);
 }
 
 void LogFile::TemporaryObject::putDelimiter()
@@ -23,7 +26,8 @@ void LogFile::TemporaryObject::putDelimiter()
   std::fputc(',', fp);
 }
 
-Logger::Logger(const std::string& fileName, const char* mode)
+Logger::Logger(const std::string& fileName, const char* mode, bool linefeed_)
+  : fp(nullptr), linefeed(linefeed_)
 {
   fp = std::fopen(getFileName(fileName).c_str(), mode);
   assert(fp != nullptr);

--- a/src/module/Logger.cpp
+++ b/src/module/Logger.cpp
@@ -23,20 +23,15 @@ void LogFile::TemporaryObject::putDelimiter()
   std::fputc(',', fp);
 }
 
-Logger::Logger(const std::string& fileName, const char* mode)
+Logger::Logger(const char* fileName, const char* mode)
 {
-  fp = std::fopen(getFileName(fileName).c_str(), mode);
+  fp = fopen(fileName, mode);
   assert(fp != nullptr);
 }
 
 Logger::~Logger()
 {
-  std::fclose(fp);
-}
-
-const std::string& Logger::getFileName(const std::string& fileName) const
-{
-  return fileName;
+  fclose(fp);
 }
 
 void Logger::write(const char* format, ...)

--- a/src/module/Logger.h
+++ b/src/module/Logger.h
@@ -82,9 +82,9 @@ class Logger {
  public:
   /**
    * @brief ファイルポインターを確保するコンストラクター
-   * @param mode [ファイルの書き込みモード（デフォルトでは追記）]
+   * @param mode [ファイルの書き込みモード（デフォルトでは書き込みモード）]
    */
-  Logger(const std::string& fileName = "log.csv", const char* mode = "a");
+  Logger(const std::string& fileName = "log.csv", const char* mode = "w");
 
   /**
    * @brief ファイルポインターを解放するデストラクター

--- a/src/module/Logger.h
+++ b/src/module/Logger.h
@@ -17,11 +17,12 @@ namespace LogFile {
    private:
     FILE* fp;
     bool isHead;
+    bool linefeed;
 
    public:
-    TemporaryObject(FILE* fp_);
+    TemporaryObject(FILE* fp_, bool linefeed_);
     /**
-     * @brief 行末に改行を挿入する
+     * @brief 行末に改行を挿入する (linefeedがtrueのとき)
      */
     ~TemporaryObject();
     /**
@@ -32,7 +33,8 @@ namespace LogFile {
 
     /**
      * @brief 整数型のデータを出力ファイルに書き込む
-     * @detail Usage: foo << 1 << 2 << 3; (自動的にデリミターと改行が挿入される)
+     * @detail Usage: foo << 1 << 2 << 3;
+     * (自動的にデリミターと、linefeedがtrueのとき改行が挿入される)
      * @param intValue [整数型(int, unsigned int, std::int8_t, etc...)]
      */
     template <typename T,
@@ -46,7 +48,8 @@ namespace LogFile {
 
     /**
      * @brief 浮動小数点数型のデータを出力ファイルに書き込む
-     * @detail Usage: foo << 1.2 << 2.4 << 3.98; (自動的にデリミターと改行が挿入される)
+     * @detail Usage: foo << 1.2 << 2.4 << 3.98;
+     * (自動的にデリミターと、linefeedがtrueのとき改行が挿入される)
      * @param floatingPointValue [浮動小数点数型(float, double)]
      */
     template <typename T,
@@ -61,7 +64,8 @@ namespace LogFile {
 
     /**
      * @brief 文字列を出力ファイルに書き込む
-     * @detail Usage: foo << "aa" << "bb" (自動的にデリミタ―と改行が挿入される)
+     * @detail Usage: foo << "aa" << "bb"
+     * (自動的にデリミターと、linefeedがtrueのとき改行が挿入される)
      * @param stringLiteral [文字列型（const char*)]
      */
     template <typename T,
@@ -78,13 +82,15 @@ namespace LogFile {
 class Logger {
  private:
   FILE* fp;
+  bool linefeed;
 
  public:
   /**
    * @brief ファイルポインターを確保するコンストラクター
    * @param mode [ファイルの書き込みモード（デフォルトでは書き込みモード）]
+   * @param linefeed_ [<<演算子を用いたとき、自動的に改行を入れるかどうか（デフォルトでは挿入する）]
    */
-  Logger(const std::string& fileName = "log.csv", const char* mode = "w");
+  Logger(const std::string& fileName = "log.csv", const char* mode = "w", bool linefeed_ = true);
 
   /**
    * @brief ファイルポインターを解放するデストラクター
@@ -105,13 +111,14 @@ class Logger {
 
   /**
    * @brief 指定したデータを出力ファイルに書き込む
-   * @detail Usage: foo << 1 << 2.4 << "aa"; (自動的にデリミターと改行が挿入される)
+   * @detail Usage: foo << 1 << 2.4 << "aa";
+   * (自動的にデリミターと、linefeedがtrueのとき改行が挿入される)
    * @param data [記録するデータ]
    */
   template <typename T>
   LogFile::TemporaryObject operator<<(T data)
   {
-    LogFile::TemporaryObject object(fp);
+    LogFile::TemporaryObject object(fp, linefeed);
     object << data;
     return object;
   }

--- a/src/module/Logger.h
+++ b/src/module/Logger.h
@@ -17,12 +17,11 @@ namespace LogFile {
    private:
     FILE* fp;
     bool isHead;
-    bool linefeed;
 
    public:
-    TemporaryObject(FILE* fp_, bool linefeed_);
+    TemporaryObject(FILE* fp_);
     /**
-     * @brief 行末に改行を挿入する (linefeedがtrueのとき)
+     * @brief 行末に改行を挿入する
      */
     ~TemporaryObject();
     /**
@@ -33,8 +32,7 @@ namespace LogFile {
 
     /**
      * @brief 整数型のデータを出力ファイルに書き込む
-     * @detail Usage: foo << 1 << 2 << 3;
-     * (自動的にデリミターと、linefeedがtrueのとき改行が挿入される)
+     * @detail Usage: foo << 1 << 2 << 3; (自動的にデリミターと改行が挿入される)
      * @param intValue [整数型(int, unsigned int, std::int8_t, etc...)]
      */
     template <typename T,
@@ -48,8 +46,7 @@ namespace LogFile {
 
     /**
      * @brief 浮動小数点数型のデータを出力ファイルに書き込む
-     * @detail Usage: foo << 1.2 << 2.4 << 3.98;
-     * (自動的にデリミターと、linefeedがtrueのとき改行が挿入される)
+     * @detail Usage: foo << 1.2 << 2.4 << 3.98; (自動的にデリミターと改行が挿入される)
      * @param floatingPointValue [浮動小数点数型(float, double)]
      */
     template <typename T,
@@ -64,8 +61,7 @@ namespace LogFile {
 
     /**
      * @brief 文字列を出力ファイルに書き込む
-     * @detail Usage: foo << "aa" << "bb"
-     * (自動的にデリミターと、linefeedがtrueのとき改行が挿入される)
+     * @detail Usage: foo << "aa" << "bb" (自動的にデリミターと改行が挿入される)
      * @param stringLiteral [文字列型（const char*)]
      */
     template <typename T,
@@ -82,15 +78,13 @@ namespace LogFile {
 class Logger {
  private:
   FILE* fp;
-  bool linefeed;
 
  public:
   /**
    * @brief ファイルポインターを確保するコンストラクター
-   * @param mode [ファイルの書き込みモード（デフォルトでは書き込みモード）]
-   * @param linefeed_ [<<演算子を用いたとき、自動的に改行を入れるかどうか（デフォルトでは挿入する）]
+   * @param mode [ファイルの書き込みモード（デフォルトでは追記）]
    */
-  Logger(const std::string& fileName = "log.csv", const char* mode = "w", bool linefeed_ = true);
+  Logger(const std::string& fileName = "log.csv", const char* mode = "a");
 
   /**
    * @brief ファイルポインターを解放するデストラクター
@@ -111,14 +105,13 @@ class Logger {
 
   /**
    * @brief 指定したデータを出力ファイルに書き込む
-   * @detail Usage: foo << 1 << 2.4 << "aa";
-   * (自動的にデリミターと、linefeedがtrueのとき改行が挿入される)
+   * @detail Usage: foo << 1 << 2.4 << "aa"; (自動的にデリミターと改行が挿入される)
    * @param data [記録するデータ]
    */
   template <typename T>
   LogFile::TemporaryObject operator<<(T data)
   {
-    LogFile::TemporaryObject object(fp, linefeed);
+    LogFile::TemporaryObject object(fp);
     object << data;
     return object;
   }

--- a/src/module/Logger.h
+++ b/src/module/Logger.h
@@ -84,7 +84,7 @@ class Logger {
    * @brief ファイルポインターを確保するコンストラクター
    * @param mode [ファイルの書き込みモード（デフォルトでは追記）]
    */
-  Logger(const char* mode = "a");
+  Logger(const std::string& fileName = "log.csv", const char* mode = "a");
 
   /**
    * @brief ファイルポインターを解放するデストラクター
@@ -94,7 +94,7 @@ class Logger {
   /**
    * @brief 出力ファイル名を返す
    */
-  std::string getFileName();
+  const std::string& getFileName(const std::string& fileName) const;
 
   /**
    * @brief 指定したデータを出力ファイルに書き込む

--- a/src/module/Logger.h
+++ b/src/module/Logger.h
@@ -9,7 +9,6 @@
 #include <cstdio>
 #include <cstdarg>
 #include <cassert>
-#include <string>
 #include <type_traits>
 
 namespace LogFile {
@@ -82,19 +81,14 @@ class Logger {
  public:
   /**
    * @brief ファイルポインターを確保するコンストラクター
-   * @param mode [ファイルの書き込みモード（デフォルトでは追記）]
+   * @param mode [ファイルの書き込みモード（デフォルトでは新規書き込み）]
    */
-  Logger(const std::string& fileName = "log.csv", const char* mode = "a");
+  Logger(const char* fileName = "log.csv", const char* mode = "w");
 
   /**
    * @brief ファイルポインターを解放するデストラクター
    */
   ~Logger();
-
-  /**
-   * @brief 出力ファイル名を返す
-   */
-  const std::string& getFileName(const std::string& fileName) const;
 
   /**
    * @brief 指定したデータを出力ファイルに書き込む

--- a/test/LoggerTest.cpp
+++ b/test/LoggerTest.cpp
@@ -5,15 +5,18 @@
  */
 #include <gtest/gtest.h>
 #include <fstream>
-#include <string>
-#include <sstream>
-#include <vector>
 #include "Logger.h"
-#include <iostream>
 
 namespace etrobocon2019_test {
   TEST(Logger, construct) { Logger logger; }
 
+  TEST(Logger, construct_fileName)
+  {
+    Logger logger("log101.csv");  // ファイル名は適当
+    // 出力ファイルが存在することを確認する
+    std::ifstream ifs("log101.csv");
+    ASSERT_TRUE(ifs.is_open());
+  }
   TEST(Logger, writeTest)
   {
     Logger logger;


### PR DESCRIPTION
### 変更点
 - ファイル名をコンストラクターで指定できるようにした
 - モードをデフォルトでwに設定するようにした

### 実機テストの結果（実機テストが必要な場合）
デフォルトのファイル名（"`log.csv`"）とファイル名を指定してログファイルを作成し、
そのどちらのファイルも正しく値が出力できていることを確認した