### PR TITLE
closed #87  LineTracerクラスでSpeedControlクラスを利用できるようにする

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get install -y \
     graphviz \
     astyle \ 
     vim \   
+    gdb \
     && apt-get clean && rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/*
 
 USER etrobo

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,8 @@
     "extensions": [
         "formulahendry.terminal",
         "ms-vscode.cpptools",
-        "streetsidesoftware.code-spell-checker"
+        "streetsidesoftware.code-spell-checker",
+        "github.vscode-pull-request-github"
     ],
     "service": "etrobo-docker",
     "workspaceFolder": "/home/hrp2/sdk/workspace/product",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-    "name": "ETrobo-docker",
+    "name": "etrobo-docker",
     "dockerComposeFile": "docker-compose.yml",
     "extensions": [
         "formulahendry.terminal",

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -10,3 +10,7 @@ services:
     environment:
       SHELL: "/bin/bash"
       HOME: "/home/etrobo"
+    cap_add:
+      - SYS_PTRACE
+    security_opt:
+      - seccomp=unconfined

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,16 +5,23 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "(lldb) Launch",
+            "name": "(gdb) Launch",
             "type": "cppdbg",
             "request": "launch",
-            "program": "${workspaceFolder}/test/a.out",
+            "program": "${workspaceFolder}/build/pandora_test",
             "args": [],
             "stopAtEntry": false,
             "cwd": "${workspaceFolder}",
             "environment": [],
-            "externalConsole": true,
-            "MIMode": "lldb"
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                }
+            ]
         },
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,12 +15,16 @@
         "Miyazaki",
         "Oiwane",
         "PORTID",
+        "Tatsumi",
         "Toyohashi",
+        "cpptools",
         "ertl",
         "etrobocon",
         "exinf",
+        "formulahendry",
         "hackev",
         "hiro",
+        "streetsidesoftware",
         "tslp"
     ],
     "cSpell.enabledLanguageIds": [

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -11,7 +11,8 @@
             "group": {
                 "kind": "build",
                 "isDefault": true
-            }
+            },
+            "problemMatcher": []
         },
         {
             "label": "build debug",
@@ -28,10 +29,7 @@
             "type": "shell",
             "command": "${workspaceFolder}/gtest_all.sh",
             "args": [],
-            "group": {
-                "kind": "test",
-                "isDefault": true
-            }
+            "group": "test"
         },
         {
             "label": "test instant",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,47 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "type": "shell",
+            "command": "${workspaceFolder}/make.sh",
+            "args": [],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        },
+        {
+            "label": "build debug",
+            "type": "shell",
+            "command": "${workspaceFolder}/test/gtest/gtest_debugging.sh",
+            "args": [],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        },
+        {
+            "label": "test",
+            "type": "shell",
+            "command": "${workspaceFolder}/gtest_all.sh",
+            "args": [],
+            "group": {
+                "kind": "test",
+                "isDefault": true
+            }
+        },
+        {
+            "label": "test instant",
+            "type": "shell",
+            "command": "${workspaceFolder}/gtest_instant.sh",
+            "args": [],
+            "group": {
+                "kind": "test",
+                "isDefault": true
+            }
+        }
+    ]
+}

--- a/src/module/LineTracer.cpp
+++ b/src/module/LineTracer.cpp
@@ -14,6 +14,7 @@ LineTracer::LineTracer(int targetBrightness_, bool isLeftCourse_)
   : targetBrightness(targetBrightness_),
     isLeftCourse(isLeftCourse_),
     distance(),
+    speedControl(controller, 0.0, 0.0, 0.0, 0.0),
     turnControl(targetBrightness_, 0.0, 0.0, 0.0)
 {
 }
@@ -37,18 +38,14 @@ void LineTracer::run(NormalCourseProperty& settings)
 
   // 目標距離を走り終えるまでループ
   while(currentDistance - initialDistance < settings.targetDistance) {
+    // 前進値の計算
+    speedValue = speedControl.calculateSpeed(settings.targetSpeed, settings.speedPid.kp,
+                                             settings.speedPid.ki, settings.speedPid.kd);
+
     // 旋回値の計算
     turnValue
         = turnControl.calculateTurn(controller.getBrightness(), targetBrightness,
                                     settings.turnPid.kp, settings.turnPid.ki, settings.turnPid.kd);
-
-    // 前進値の計算
-    speedValue = 30;
-    /* NOTE: 後日実装予定
-    speedValue = speedControl.calculateSpeed(
-        settings.speedPid.kp, settings.speedPid.ki, settings.speedPid.kd,
-        settings.targetSpeed);
-    */
 
     // モータ出力の計算
     if(isLeftCourse) {
@@ -68,6 +65,7 @@ void LineTracer::run(NormalCourseProperty& settings)
     // 現在の走行距離の取得
     currentDistance
         = distance.getDistance(controller.getLeftMotorCount(), controller.getRightMotorCount());
+    controller.tslpTsk(4);
   }
 }
 

--- a/src/module/LineTracer.cpp
+++ b/src/module/LineTracer.cpp
@@ -40,13 +40,13 @@ void LineTracer::run(NormalCourseProperty& settings)
   // 目標距離を走り終えるまでループ
   while(currentDistance - initialDistance < settings.targetDistance) {
     // 前進値の計算
-    speedValue = speedControl.calculateSpeed(settings.targetSpeed, settings.speedPid.kp,
-                                             settings.speedPid.ki, settings.speedPid.kd);
+    speedValue = speedControl.calculateSpeed(settings.targetSpeed, settings.speedPid.Kp,
+                                             settings.speedPid.Ki, settings.speedPid.Kd);
 
     // 旋回値の計算
     turnValue
         = turnControl.calculateTurn(controller.getBrightness(), targetBrightness,
-                                    settings.turnPid.kp, settings.turnPid.ki, settings.turnPid.kd);
+                                    settings.turnPid.Kp, settings.turnPid.Ki, settings.turnPid.Kd);
 
     // モータ出力の計算
     if(isLeftCourse) {

--- a/src/module/LineTracer.cpp
+++ b/src/module/LineTracer.cpp
@@ -10,8 +10,9 @@
  *  @param targetBrightness_  [カラーセンサーの目標値]
  *  @param isLeftCourse_ [Leftコースである場合True]
  */
-LineTracer::LineTracer(int targetBrightness_, bool isLeftCourse_)
-  : targetBrightness(targetBrightness_),
+LineTracer::LineTracer(Controller& controller_, int targetBrightness_, bool isLeftCourse_)
+  : controller(controller_),
+    targetBrightness(targetBrightness_),
     isLeftCourse(isLeftCourse_),
     distance(),
     speedControl(controller, 0.0, 0.0, 0.0, 0.0),

--- a/src/module/LineTracer.cpp
+++ b/src/module/LineTracer.cpp
@@ -6,10 +6,6 @@
 
 #include "LineTracer.h"
 
-/** コンストラクタ
- *  @param targetBrightness_  [カラーセンサーの目標値]
- *  @param isLeftCourse_ [Leftコースである場合True]
- */
 LineTracer::LineTracer(Controller& controller_, int targetBrightness_, bool isLeftCourse_)
   : controller(controller_),
     targetBrightness(targetBrightness_),
@@ -20,11 +16,6 @@ LineTracer::LineTracer(Controller& controller_, int targetBrightness_, bool isLe
 {
 }
 
-/** 指定された距離だけ走行する。
- *  @brief 走行距離や目標スピード、スピード制御PID、回転制御PIDを NormalCourseProperty
- * 構造体を使用し渡す。
- *  @param settings [各種パラメータが入っている NormalCourseProperty 構造体]
- */
 void LineTracer::run(NormalCourseProperty& settings)
 {
   // 関数呼び出し時の走行距離を取得・設定
@@ -70,10 +61,6 @@ void LineTracer::run(NormalCourseProperty& settings)
   }
 }
 
-/** セッター
- *  @brief カラーセンサーの目標値を再設定する
- *  @param targetBrightness_ [カラーセンサーの目標値]
- */
 void LineTracer::setTargetBrightness(int targetBrightness_)
 {
   targetBrightness = targetBrightness_;

--- a/src/module/LineTracer.h
+++ b/src/module/LineTracer.h
@@ -28,13 +28,15 @@ class LineTracer
 {
 public:
     /** コンストラクタ
+     *  @param controller_  [Controller]
      *  @param targetBrightness_  [カラーセンサーの目標値]
      *  @param isLeftCourse_ [Leftコースである場合True]
      */
     LineTracer(Controller& controller_, int targetBrightness_, bool isLeftCourse_);
 
     /** 指定された距離だけ走行する。
-     *  @brief 走行距離や目標スピード、スピード制御PID、回転制御PIDを NormalCourseProperty 構造体を使用し渡す。
+     *  @brief 走行距離や目標スピード、スピード制御PID、回転制御PIDを NormalCourseProperty
+     * 構造体を使用し渡す。
      *  @param settings [各種パラメータが入っている NormalCourseProperty 構造体]
      */
     void run(NormalCourseProperty &settings);

--- a/src/module/LineTracer.h
+++ b/src/module/LineTracer.h
@@ -10,16 +10,7 @@
 #include "Distance.h"
 #include "SpeedControl.h"
 #include "TurnControl.h"
-
-struct PidParameter
-{
-    // p値
-    double kp;
-    // k値
-    double ki;
-    // d値
-    double kd;
-};
+#include "Pid.h"
 
 struct NormalCourseProperty
 {
@@ -28,9 +19,9 @@ struct NormalCourseProperty
     // 目標スピード
     int targetSpeed;
     // speedPid
-    PidParameter speedPid;
+    PidGain speedPid;
     // turnPid
-    PidParameter turnPid;
+    PidGain turnPid;
 };
 
 class LineTracer

--- a/src/module/LineTracer.h
+++ b/src/module/LineTracer.h
@@ -8,8 +8,7 @@
 
 #include "Controller.h"
 #include "Distance.h"
-// NOTE: 後日実装予定
-//#include "SpeedControl.h"
+#include "SpeedControl.h"
 #include "TurnControl.h"
 
 struct PidParameter
@@ -60,8 +59,7 @@ private:
     bool isLeftCourse;
     Distance distance;
 
-    // NOTE: 後日実装予定
-    //SpeedControl speedControl;
+    SpeedControl speedControl;
     TurnControl turnControl;
     Controller controller;
 };

--- a/src/module/LineTracer.h
+++ b/src/module/LineTracer.h
@@ -40,7 +40,7 @@ public:
      *  @param targetBrightness_  [カラーセンサーの目標値]
      *  @param isLeftCourse_ [Leftコースである場合True]
      */
-    LineTracer(int targetBrightness_, bool isLeftCourse_);
+    LineTracer(Controller& controller_, int targetBrightness_, bool isLeftCourse_);
 
     /** 指定された距離だけ走行する。
      *  @bfief 走行距離や目標スピード、スピード制御PID、回転制御PIDを NormalCourseProperty 構造体を使用し渡す。
@@ -55,13 +55,13 @@ public:
     void setTargetBrightness(int targetBrightness_);
 
 private:
+    Controller& controller;
     int targetBrightness;
     bool isLeftCourse;
     Distance distance;
 
     SpeedControl speedControl;
     TurnControl turnControl;
-    Controller controller;
 };
 
 #endif

--- a/src/module/LineTracer.h
+++ b/src/module/LineTracer.h
@@ -12,49 +12,47 @@
 #include "TurnControl.h"
 #include "Pid.h"
 
-struct NormalCourseProperty
-{
-    // 目標距離
-    int targetDistance;
-    // 目標スピード
-    int targetSpeed;
-    // speedPid
-    PidGain speedPid;
-    // turnPid
-    PidGain turnPid;
+struct NormalCourseProperty {
+  // 目標距離
+  int targetDistance;
+  // 目標スピード
+  int targetSpeed;
+  // speedPid
+  PidGain speedPid;
+  // turnPid
+  PidGain turnPid;
 };
 
-class LineTracer
-{
-public:
-    /** コンストラクタ
-     *  @param controller_  [Controller]
-     *  @param targetBrightness_  [カラーセンサーの目標値]
-     *  @param isLeftCourse_ [Leftコースである場合True]
-     */
-    LineTracer(Controller& controller_, int targetBrightness_, bool isLeftCourse_);
+class LineTracer {
+ public:
+  /** コンストラクタ
+   *  @param controller_  [Controller]
+   *  @param targetBrightness_  [カラーセンサーの目標値]
+   *  @param isLeftCourse_ [Leftコースである場合True]
+   */
+  LineTracer(Controller& controller_, int targetBrightness_, bool isLeftCourse_);
 
-    /** 指定された距離だけ走行する。
-     *  @brief 走行距離や目標スピード、スピード制御PID、回転制御PIDを NormalCourseProperty
-     * 構造体を使用し渡す。
-     *  @param settings [各種パラメータが入っている NormalCourseProperty 構造体]
-     */
-    void run(NormalCourseProperty &settings);
+  /** 指定された距離だけ走行する。
+   *  @brief 走行距離や目標スピード、スピード制御PID、回転制御PIDを NormalCourseProperty
+   * 構造体を使用し渡す。
+   *  @param settings [各種パラメータが入っている NormalCourseProperty 構造体]
+   */
+  void run(NormalCourseProperty& settings);
 
-    /** セッター
-     *  @brief カラーセンサーの目標値を再設定する
-     *  @param targetBrightness_ [カラーセンサーの目標値]
-     */
-    void setTargetBrightness(int targetBrightness_);
+  /** セッター
+   *  @brief カラーセンサーの目標値を再設定する
+   *  @param targetBrightness_ [カラーセンサーの目標値]
+   */
+  void setTargetBrightness(int targetBrightness_);
 
-private:
-    Controller& controller;
-    int targetBrightness;
-    bool isLeftCourse;
-    Distance distance;
+ private:
+  Controller& controller;
+  int targetBrightness;
+  bool isLeftCourse;
+  Distance distance;
 
-    SpeedControl speedControl;
-    TurnControl turnControl;
+  SpeedControl speedControl;
+  TurnControl turnControl;
 };
 
 #endif

--- a/src/module/LineTracer.h
+++ b/src/module/LineTracer.h
@@ -34,13 +34,13 @@ public:
     LineTracer(Controller& controller_, int targetBrightness_, bool isLeftCourse_);
 
     /** 指定された距離だけ走行する。
-     *  @bfief 走行距離や目標スピード、スピード制御PID、回転制御PIDを NormalCourseProperty 構造体を使用し渡す。
+     *  @brief 走行距離や目標スピード、スピード制御PID、回転制御PIDを NormalCourseProperty 構造体を使用し渡す。
      *  @param settings [各種パラメータが入っている NormalCourseProperty 構造体]
      */
     void run(NormalCourseProperty &settings);
 
     /** セッター
-     *  @bfief カラーセンサーの目標値を再設定する
+     *  @brief カラーセンサーの目標値を再設定する
      *  @param targetBrightness_ [カラーセンサーの目標値]
      */
     void setTargetBrightness(int targetBrightness_);

--- a/src/module/NormalCourse.cpp
+++ b/src/module/NormalCourse.cpp
@@ -40,7 +40,7 @@ void NormalCourse::runNormalCourse()
       = { { { 1000, 300, { 0.1, 0.0, 0.0 }, { 0.4, 0.01, 0.0 } },     // 第1区間
             { 500, 80, { 0.1, 0.0, 0.0 }, { 0.1, 0.01, 0.0 } } } };  // 第2区間
 
-  LineTracer lineTracer(targetBrightness, isLeftCourse);
+  LineTracer lineTracer(controller, targetBrightness, isLeftCourse);
   for(auto& ncp : normalCourseProperty) {
     lineTracer.run(ncp);
     // １区間終わるごとに音を奏でる．

--- a/src/module/NormalCourse.cpp
+++ b/src/module/NormalCourse.cpp
@@ -37,7 +37,7 @@ void NormalCourse::runNormalCourse()
        * 詳しく見たいならLineTracer.hを見てね．
        * 進む距離，目標スピード，スピードpid，ターンpid
        */
-      = { { { 1000, 10, { 0.1, 0.0, 0.0 }, { 0.1, 0.01, 0.0 } },     // 第1区間
+      = { { { 1000, 300, { 0.1, 0.0, 0.0 }, { 0.4, 0.01, 0.0 } },     // 第1区間
             { 500, 80, { 0.1, 0.0, 0.0 }, { 0.1, 0.01, 0.0 } } } };  // 第2区間
 
   LineTracer lineTracer(targetBrightness, isLeftCourse);

--- a/src/module/SpeedControl.cpp
+++ b/src/module/SpeedControl.cpp
@@ -6,14 +6,6 @@
 
 #include "SpeedControl.h"
 
-/**
- *  コンストラクタ
- *  @param  tragetSpeed       [目標速度]
- *  @param  Kp                [Pゲイン]
- *  @param  Ki                [Iゲイン]
- *  @param  Kd                [Dゲイン]
- */
-
 SpeedControl::SpeedControl(Controller& controller_, int targetSpeed, double Kp, double Ki,
                            double Kd)
   : controller(controller_), dist(), pid(targetSpeed, Kp, Ki, Kd)
@@ -25,15 +17,6 @@ SpeedControl::SpeedControl(Controller& controller_, int targetSpeed, double Kp, 
   // 走行距離の取得[mm]
   prevDistance = dist.getDistance(leftAngle, rightAngle);
 }
-
-/**
- *  [SpeedControl::calculateSpeed]
- *  @param  targetSpeed [目標の速度] [mm/s]
- *  @param  Kp          [Pゲイン]
- *  @param  Ki          [Iゲイン]
- *  @param  Kd          [Dゲイン]
- *  @return             [PWM値]
- */
 
 double SpeedControl::calculateSpeed(int targetSpeed, double Kp, double Ki, double Kd)
 {

--- a/src/module/SpeedControl.cpp
+++ b/src/module/SpeedControl.cpp
@@ -48,7 +48,7 @@ double SpeedControl::calculateSpeed(int targetSpeed, double Kp, double Ki, doubl
   double nextDistance = dist.getDistance(leftAngle, rightAngle);
 
   //現在の速度を求める
-  double currentSpeed = (nextDistance - prevDistance) / 0.004;
+  double currentSpeed = nextDistance - prevDistance;
 
   //prevDistanceの更新
   prevDistance = dist.getDistance(leftAngle, rightAngle);

--- a/src/module/SpeedControl.cpp
+++ b/src/module/SpeedControl.cpp
@@ -33,7 +33,7 @@ double SpeedControl::calculateSpeed(int targetSpeed, double Kp, double Ki, doubl
   //現在の速度を求める
   double currentSpeed = nextDistance - prevDistance;
 
-  //prevDistanceの更新
+  // prevDistanceの更新
   prevDistance = dist.getDistance(leftAngle, rightAngle);
 
   // pid値を求める

--- a/src/module/SpeedControl.h
+++ b/src/module/SpeedControl.h
@@ -18,7 +18,24 @@ class SpeedControl {
   double prevDistance;
 
  public:
+  /**
+   *  コンストラクタ
+   *  @param  controller_       [Controller]
+   *  @param  targetSpeed       [目標速度]
+   *  @param  Kp                [Pゲイン]
+   *  @param  Ki                [Iゲイン]
+   *  @param  Kd                [Dゲイン]
+   */
   SpeedControl(Controller& controller_, int targetSpeed, double Kp, double Ki, double Kd);
+
+  /**
+   *  [SpeedControl::calculateSpeed]
+   *  @param  targetSpeed [目標の速度] [mm/s]
+   *  @param  Kp          [Pゲイン]
+   *  @param  Ki          [Iゲイン]
+   *  @param  Kd          [Dゲイン]
+   *  @return             [PWM値]
+   */
   double calculateSpeed(int targetSpeed, double Kp, double Ki, double Kd);
 };
 

--- a/test/LineTracerTest.cpp
+++ b/test/LineTracerTest.cpp
@@ -7,43 +7,41 @@
 #include "Controller.h"
 #include <gtest/gtest.h>
 
-namespace etrobocon2019_test
-{
-TEST(LineTracer, LineTracer_init)
-{
+namespace etrobocon2019_test {
+  TEST(LineTracer, LineTracer_init)
+  {
     Controller controller;
-    int targetBrightness = 50; //カラーセンサーの目標値
-    bool isRight = true;       //Right コースであるか、否か
+    int targetBrightness = 50;  //カラーセンサーの目標値
+    bool isRight = true;        // Right コースであるか、否か
 
     LineTracer lineTracer(controller, targetBrightness, isRight);
-}
+  }
 
-TEST(LineTracer, run)
-{
+  TEST(LineTracer, run)
+  {
     Controller controller;
-    int targetBrightness = 50; //カラーセンサーの目標値
-    bool isRight = true;       //Right コースであるか、否か
+    int targetBrightness = 50;  //カラーセンサーの目標値
+    bool isRight = true;        // Right コースであるか、否か
 
     LineTracer lineTracer(controller, targetBrightness, isRight);
 
     // 走行用の設定
-    NormalCourseProperty settings =
-        {100, 100, {0.1, 0.001, 0.0}, {0.6, 0.001, 0.0}};
+    NormalCourseProperty settings = { 100, 100, { 0.1, 0.001, 0.0 }, { 0.6, 0.001, 0.0 } };
 
     // 走行する
     lineTracer.run(settings);
-}
+  }
 
-TEST(LineTracer, setTargetBrightness)
-{
+  TEST(LineTracer, setTargetBrightness)
+  {
     Controller controller;
-    int targetBrightness = 50; //カラーセンサーの目標値
-    bool isRight = true;       //Right コースであるか、否か
+    int targetBrightness = 50;  //カラーセンサーの目標値
+    bool isRight = true;        // Right コースであるか、否か
 
     LineTracer lineTracer(controller, targetBrightness, isRight);
 
     // カラーセンサーの目標値を変更
     lineTracer.setTargetBrightness(100);
-}
+  }
 
-} // namespace etrobocon2019_test
+}  // namespace etrobocon2019_test

--- a/test/LineTracerTest.cpp
+++ b/test/LineTracerTest.cpp
@@ -25,7 +25,7 @@ TEST(LineTracer, run)
 
     // 走行用の設定
     NormalCourseProperty settings =
-        {100, 100, {1.0, 1.0, 1.0}, {1.0, 1.0, 1.0}};
+        {100, 100, {0.1, 0.001, 0.0}, {0.6, 0.001, 0.0}};
 
     // 走行する
     lineTracer.run(settings);

--- a/test/LineTracerTest.cpp
+++ b/test/LineTracerTest.cpp
@@ -4,24 +4,27 @@
  *  @author Takahiro55555
  */
 #include "LineTracer.h"
+#include "Controller.h"
 #include <gtest/gtest.h>
 
 namespace etrobocon2019_test
 {
 TEST(LineTracer, LineTracer_init)
 {
+    Controller controller;
     int targetBrightness = 50; //カラーセンサーの目標値
     bool isRight = true;       //Right コースであるか、否か
 
-    LineTracer lineTracer(targetBrightness, isRight);
+    LineTracer lineTracer(controller, targetBrightness, isRight);
 }
 
 TEST(LineTracer, run)
 {
+    Controller controller;
     int targetBrightness = 50; //カラーセンサーの目標値
     bool isRight = true;       //Right コースであるか、否か
 
-    LineTracer lineTracer(targetBrightness, isRight);
+    LineTracer lineTracer(controller, targetBrightness, isRight);
 
     // 走行用の設定
     NormalCourseProperty settings =
@@ -33,10 +36,11 @@ TEST(LineTracer, run)
 
 TEST(LineTracer, setTargetBrightness)
 {
+    Controller controller;
     int targetBrightness = 50; //カラーセンサーの目標値
     bool isRight = true;       //Right コースであるか、否か
 
-    LineTracer lineTracer(targetBrightness, isRight);
+    LineTracer lineTracer(controller, targetBrightness, isRight);
 
     // カラーセンサーの目標値を変更
     lineTracer.setTargetBrightness(100);

--- a/test/SpeedControlTest.cpp
+++ b/test/SpeedControlTest.cpp
@@ -39,7 +39,7 @@ namespace etrobocon2019_test {
     //現在の速度を求める
     double currentSpeed = (nextDistance - prevDistance) / 0.004;
 
-    //prevDistanceの更新
+    // prevDistanceの更新
     prevDistance = nextDistance;
 
     // pid値を求める

--- a/test/gtest/gtest_debugging.sh
+++ b/test/gtest/gtest_debugging.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -eu
+
+if [ -e product ]; then
+    cd product
+fi
+
+cd build
+
+cmake -DCMAKE_BUILD_TYPE=Debug ..
+cmake --build .


### PR DESCRIPTION
### 変更点
- SpeedControlを組込
- devcontainer内でテストをデバッグできるようにした
- `SpeedControl::calculateSpeed()`内の、**`0.004`で割る**処理を削除。
```
double currentSpeed = (nextDistance - prevDistance) / 0.004;
↓
double currentSpeed = nextDistance - prevDistance;
```

### 実機テストの結果（実機テストが必要な場合）
ライントレース中の速度制御が成功したことをちっちゃいコースで確認した。