### PR TITLE
closed #82 #124 turnValueがspeedValueを超えないようにした && LRコース27秒で完走する設定

### DIFF
--- a/src/module/LineTracer.cpp
+++ b/src/module/LineTracer.cpp
@@ -5,7 +5,7 @@
  */
 
 #include "LineTracer.h"
-#include "Logger.h"
+//#include "Logger.h"
 
 LineTracer::LineTracer(Controller& controller_, int targetBrightness_, bool isLeftCourse_)
   : controller(controller_),
@@ -15,12 +15,14 @@ LineTracer::LineTracer(Controller& controller_, int targetBrightness_, bool isLe
     speedControl(controller, 0.0, 0.0, 0.0, 0.0),
     turnControl(targetBrightness_, 0.0, 0.0, 0.0)
 {
+  /*
   Logger logger{ "w" };
   logger << "brightness"
          << "speed"
          << "turn"
          << "LEFT"
          << "RIGHT";
+  */
 }
 
 void LineTracer::run(NormalCourseProperty& settings)
@@ -34,7 +36,7 @@ void LineTracer::run(NormalCourseProperty& settings)
   int speedValue = 0;                     // 直進値
   int leftPWM = 0;                        // 左モータの出力
   int rightPWM = 0;                       // 右モータの出力
-  Logger logger{ "a" };
+  //Logger logger{ "a" };
 
   // 目標距離を走り終えるまでループ
   while(currentDistance - initialDistance < settings.targetDistance) {
@@ -57,7 +59,7 @@ void LineTracer::run(NormalCourseProperty& settings)
       leftPWM = speedValue + turnValue;
       rightPWM = speedValue - turnValue;
     }
-    logger << controller.getBrightness() << speedValue << turnValue << leftPWM << rightPWM;
+    //logger << controller.getBrightness() << speedValue << turnValue << leftPWM << rightPWM;
     // PWM値の設定
     controller.setLeftMotorPwm(leftPWM);
     controller.setRightMotorPwm(rightPWM);

--- a/src/module/LineTracer.cpp
+++ b/src/module/LineTracer.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "LineTracer.h"
+#include "Logger.h"
 
 LineTracer::LineTracer(Controller& controller_, int targetBrightness_, bool isLeftCourse_)
   : controller(controller_),
@@ -14,6 +15,12 @@ LineTracer::LineTracer(Controller& controller_, int targetBrightness_, bool isLe
     speedControl(controller, 0.0, 0.0, 0.0, 0.0),
     turnControl(targetBrightness_, 0.0, 0.0, 0.0)
 {
+  Logger logger{ "w" };
+  logger << "brightness"
+         << "speed"
+         << "turn"
+         << "LEFT"
+         << "RIGHT";
 }
 
 void LineTracer::run(NormalCourseProperty& settings)
@@ -27,6 +34,7 @@ void LineTracer::run(NormalCourseProperty& settings)
   int speedValue = 0;                     // 直進値
   int leftPWM = 0;                        // 左モータの出力
   int rightPWM = 0;                       // 右モータの出力
+  Logger logger{ "a" };
 
   // 目標距離を走り終えるまでループ
   while(currentDistance - initialDistance < settings.targetDistance) {
@@ -36,7 +44,7 @@ void LineTracer::run(NormalCourseProperty& settings)
 
     // 旋回値の計算
     turnValue
-        = turnControl.calculateTurn(controller.getBrightness(), targetBrightness,
+        = turnControl.calculateTurn(speedValue, controller.getBrightness(), targetBrightness,
                                     settings.turnPid.Kp, settings.turnPid.Ki, settings.turnPid.Kd);
 
     // モータ出力の計算
@@ -49,7 +57,7 @@ void LineTracer::run(NormalCourseProperty& settings)
       leftPWM = speedValue + turnValue;
       rightPWM = speedValue - turnValue;
     }
-
+    logger << controller.getBrightness() << speedValue << turnValue << leftPWM << rightPWM;
     // PWM値の設定
     controller.setLeftMotorPwm(leftPWM);
     controller.setRightMotorPwm(rightPWM);

--- a/src/module/NormalCourse.cpp
+++ b/src/module/NormalCourse.cpp
@@ -31,15 +31,19 @@ void NormalCourse::setIsLeftCourse(bool isLeftCourse_)
 void NormalCourse::runNormalCourse()
 {
   // 配列の個数
-  constexpr int arraySize = 2;
+  constexpr int arraySize = 4;
+  int baseSpeed = 500;
   std::array<NormalCourseProperty, arraySize> normalCourseProperty
       /**
        * 詳しく見たいならLineTracer.hを見てね．
        * 進む距離，目標スピード，スピードpid，ターンpid
        */
-      = { { { 1000, 300, { 0.1, 0.0, 0.0 }, { 0.4, 0.01, 0.0 } },     // 第1区間
-            { 500, 80, { 0.1, 0.0, 0.0 }, { 0.1, 0.01, 0.0 } } } };  // 第2区間
-
+      = { {
+          { 500, baseSpeed, { 0.1, 0.0, 0.1 }, { 0.8, 0.01, 0.01 } },        // 第1区間
+          { 1000, baseSpeed - 50, { 0.1, 0.0, 0.1 }, { 0.8, 0.01, 0.05 } },  // 第2区間
+          { 5000, baseSpeed - 50, { 0.1, 0.0, 0.1 }, { 0.8, 0.01, 0.05 } },  // 第3区間
+          { 5000, baseSpeed - 50, { 0.1, 0.0, 0.1 }, { 0.8, 0.01, 0.05 } },  // 第4区間
+      } };
   LineTracer lineTracer(controller, targetBrightness, isLeftCourse);
   for(auto& ncp : normalCourseProperty) {
     lineTracer.run(ncp);

--- a/src/module/TurnControl.cpp
+++ b/src/module/TurnControl.cpp
@@ -27,11 +27,14 @@ TurnControl::TurnControl(int targetBrightness, double Kp, double Ki, double Kd)
  *  @param  Kd                [Dゲイン]
  *  @return                   [旋回値]
  */
-double TurnControl::calculateTurn(int currentBrightness, int targetBrightness, double Kp, double Ki,
-                                  double Kd)
+double TurnControl::calculateTurn(int forward, int currentBrightness, int targetBrightness,
+                                  double Kp, double Ki, double Kd)
 {
   // pidの値を更新(パラメータに変更がなくても更新する)
   pid.setParameter(static_cast<double>(targetBrightness), Kp, Ki, Kd);
 
-  return pid.control(static_cast<double>(currentBrightness));
+  auto pidValue = pid.control(static_cast<double>(currentBrightness));
+
+  double forwardPercent = forward / 100.0;
+  return pidValue * forwardPercent;
 }

--- a/src/module/TurnControl.h
+++ b/src/module/TurnControl.h
@@ -14,8 +14,8 @@ class TurnControl {
 
  public:
   TurnControl(int targetBrightness, double Kp, double Ki, double Kd);
-  double calculateTurn(int currentBrightness, int targetBrightness, double Kp, double Ki,
-                       double Kd);
+  double calculateTurn(int forward, int currentBrightness, int targetBrightness, double Kp,
+                       double Ki, double Kd);
 };
 
 #endif

--- a/test/TurnControlTest.cpp
+++ b/test/TurnControlTest.cpp
@@ -17,6 +17,19 @@ namespace etrobocon2019_test {
 
     double expectedTurnValue = pid.control(70.0);
 
-    ASSERT_DOUBLE_EQ(expectedTurnValue, turnCtrl.calculateTurn(70, 50, 0.6, 0.05, 0.04));
+    ASSERT_DOUBLE_EQ(expectedTurnValue, turnCtrl.calculateTurn(100, 70, 50, 0.6, 0.05, 0.04));
   }
-}  // namespace etrobocon2019_test
+
+    TEST(TurnControl, limitCalculateTurn)
+  {
+    TurnControl turnCtrl(50, 0.6, 0.05, 0.04);
+
+    Pid pid(50.0, 0.6, 0.05, 0.04);
+
+    double expectedTurnValue = pid.control(70.0) * 50 / 100;
+
+    ASSERT_DOUBLE_EQ(expectedTurnValue, turnCtrl.calculateTurn(50, 70, 50, 0.6, 0.05, 0.04));
+  }
+}  
+
+// namespace etrobocon2019_test


### PR DESCRIPTION
### 変更点
- TurnControlのPID値がSpeedControlを超えないように修正

SpeedValue = 30, TurnValue = 50のとき、

```
TurnValue = TurnValue * SpeedValue / 100.0
                  = 50 * 30 / 100.0
                  = 15
```

となるようにした。

- LRコースそれぞれ完走するようにした。

### 実機テストの結果（実機テストが必要な場合）
- Lコース2回走行。27秒、29秒
- Rコース2回走行。28秒、28秒

### 参考
<blockquote class="twitter-tweet"><p lang="ja" dir="ltr">とりあえずGoalまで行けるようになったぞ〜<br>今年のコースはLRが左右対称なので開発が楽でいいですね<a href="https://twitter.com/hashtag/ET%E3%83%AD%E3%83%9C%E3%82%B3%E3%83%B3?src=hash&amp;ref_src=twsrc%5Etfw">#ETロボコン</a> <a href="https://t.co/G71GGLvsxU">pic.twitter.com/G71GGLvsxU</a></p>&mdash; 片山研 (@miyazaki_katlab) <a href="https://twitter.com/miyazaki_katlab/status/1143112182080479233?ref_src=twsrc%5Etfw">June 24, 2019</a></blockquote>