### PR TITLE
closed #138 controllerクラスにジャイロセンサーを取得する関数の追加

### DIFF
--- a/src/module/api/core/Controller.cpp
+++ b/src/module/api/core/Controller.cpp
@@ -224,8 +224,15 @@ int Controller::getAngleOfRotation()
 {
   int angle = gyroSensor.getAngle();
   //角度を[0-360]の範囲で表す
-  if(angle>360) angle = angle % 360;
-  if(angle<0) angle = 360 + angle;
+  return Controller::limitAngle(angle);
+}
 
+int Controller::limitAngle(int angle)
+{
+    angle = angle % 360;
+    if (angle < 0) {
+      angle = 360 + angle;
+      angle = limitAngle(angle);
+    }
   return angle;
 }

--- a/src/module/api/core/Controller.cpp
+++ b/src/module/api/core/Controller.cpp
@@ -4,6 +4,7 @@
 Controller::Controller()
   : touchSensor(PORT_1),
     colorSensor(PORT_3),
+    gyroSensor(PORT_4),
     liftMotor(PORT_A),
     rightWheel(PORT_B),
     leftWheel(PORT_C),
@@ -217,4 +218,14 @@ void Controller::stopMotor()
 {
   leftWheel.stop();
   rightWheel.stop();
+}
+
+int Controller::getAngleOfRotation()
+{
+  int angle = gyroSensor.getAngle();
+  //角度を[0-360]の範囲で表す
+  if(angle>360) angle = angle % 360;
+  if(angle<0) angle = 360 + angle;
+
+  return angle;
 }

--- a/src/module/api/core/Controller.cpp
+++ b/src/module/api/core/Controller.cpp
@@ -223,7 +223,8 @@ void Controller::stopMotor()
 int Controller::getAngleOfRotation()
 {
   int angle = gyroSensor.getAngle();
-  //角度を[0-360]の範囲で表す
+  //角度を[0-360]の範囲で表す,
+  //右手系(反時計回り)が正である
   return Controller::limitAngle(angle);
 }
 

--- a/src/module/api/core/Controller.h
+++ b/src/module/api/core/Controller.h
@@ -71,10 +71,6 @@ class Controller {
   void setRightMotorPwm(const int pwm);
   void resetMotorCount();
   void stopMotor();
-  int getAngle();
-  int getAnglerVelocity();
-  void reset();
-  void setOffset(int offset);
   int getAngleOfRotation();
   int limitAngle(int angle);
 

--- a/src/module/api/core/Controller.h
+++ b/src/module/api/core/Controller.h
@@ -7,7 +7,7 @@
 #include "ColorSensor.h"
 #include "Motor.h"
 #include "TouchSensor.h"
-
+#include "GyroSensor.h"
 /*
  * touch_sensor = EV3_PORT_1;
  * sonar_sensor = EV3_PORT_2;
@@ -39,6 +39,7 @@ class Controller {
   TouchSensor touchSensor;
   ColorSensor colorSensor;
   Clock clock;
+  GyroSensor gyroSensor;
   // モータ入力電圧の最大値
   static constexpr int MOTOR_PWM_MAX = 100;
   // モータ入力電圧の最小値
@@ -70,8 +71,13 @@ class Controller {
   void setRightMotorPwm(const int pwm);
   void resetMotorCount();
   void stopMotor();
+  int getAngle();
+  int getAnglerVelocity();
+  void reset();
+  void setOffset(int offset);
+  int getAngleOfRotation();
 
- private:
+private:
   rgb_raw_t rgb;
   HsvStatus hsv;
   Motor liftMotor;

--- a/src/module/api/core/Controller.h
+++ b/src/module/api/core/Controller.h
@@ -76,6 +76,7 @@ class Controller {
   void reset();
   void setOffset(int offset);
   int getAngleOfRotation();
+  int limitAngle(int angle);
 
 private:
   rgb_raw_t rgb;

--- a/test/dummy/Controller.h
+++ b/test/dummy/Controller.h
@@ -47,6 +47,12 @@ class ColorSensor {
   int brightness = 0;
 };
 
+class GyroSensor{
+  public:
+    int getAngle() {}
+    int angle = 0;
+};
+
 class Controller {
  private:
   Motor rightWheel;
@@ -58,6 +64,7 @@ class Controller {
   Clock clock;
   TouchSensor touchSensor;
   ColorSensor colorSensor;
+  GyroSensor gyroSensor;
 
   // モータ入力電圧の最大値
   static constexpr int MOTOR_PWM_MAX = 100;
@@ -240,5 +247,11 @@ class Controller {
     }
     return value;
   };
+  int getAngleOfRotation()
+  { int angle = gyroSensor.getAngle();
+    if(angle>360) angle = angle % 360;
+    if(angle<0) angle = 360 + angle;
+    return angle;
+  }
 };
 #endif

--- a/test/dummy/Controller.h
+++ b/test/dummy/Controller.h
@@ -248,9 +248,18 @@ class Controller {
     return value;
   };
   int getAngleOfRotation()
-  { int angle = gyroSensor.getAngle();
-    if(angle>360) angle = angle % 360;
-    if(angle<0) angle = 360 + angle;
+  { 
+    int angle = gyroSensor.getAngle();
+
+    return limitAngle(angle);
+  }
+  int limitAngle(int angle)
+  {
+    angle = angle % 360;
+      if (angle < 0) {
+        angle = 360 + angle;
+        angle = limitAngle(angle);
+      }
     return angle;
   }
 };

--- a/test/dummy/Controller.h
+++ b/test/dummy/Controller.h
@@ -49,7 +49,7 @@ class ColorSensor {
 
 class GyroSensor{
   public:
-    int getAngle() {}
+    int getAngle() {return angle}
     int angle = 0;
 };
 

--- a/test/dummy/Controller.h
+++ b/test/dummy/Controller.h
@@ -49,7 +49,7 @@ class ColorSensor {
 
 class GyroSensor{
   public:
-    int getAngle() {return angle}
+    int getAngle() { return angle; }
     int angle = 0;
 };
 


### PR DESCRIPTION
### 変更点
controllerクラスにジャイロセンサーを取得する関数の追加
取得した角度の範囲は[0-360]とした
### 実機テストの結果（実機テストが必要な場合）
各テストは10回行った。
-反時計回りに90度回す  ->[86-93]の範囲,平均:89.9度
-反時計回りに180度回す->[175-186]の範囲,平均:179.2度
-反時計回りに270度回す->[265-276]の範囲,平均:269.9度
-反時計回りに360度回す->[351-4]の範囲,平均:356.7度

-時計回りに90度回す->[269-274]の範囲,平均:272.0度
-時計回りに180度回す->[176-186]の範囲,平均:182.0度
-時計回りに270度回す->[85-97]の範囲,平均:91.0度
-時計回りに360度回す->[350-6]の範囲,平均:1.8度

#すべて手作業でのテストであったため精度は良くない
[angleTest.xlsx](https://github.com/KatLab-MiyazakiUniv/etrobocon2019/files/3354848/angleTest.xlsx)