### PR TITLE
closed #133 特定の色まで移動する関数を追加

### DIFF
--- a/src/module/Navigator.cpp
+++ b/src/module/Navigator.cpp
@@ -31,11 +31,13 @@ void Navigator::move(double specifiedDistance, int pwm, const double pGain)
     while(hasArrived(goalDistance, false)) {
       double alpha = pid.control(controller.getLeftMotorCount() - controller.getRightMotorCount());
       setPwmValue(-std::abs(pwm), -alpha);
+      controller.tslpTsk(4);
     }
   } else {
     while(hasArrived(goalDistance, true)) {
       double alpha = pid.control(controller.getLeftMotorCount() - controller.getRightMotorCount());
       setPwmValue(std::abs(pwm), -alpha);
+      controller.tslpTsk(4);
     }
   }
 
@@ -56,12 +58,14 @@ void Navigator::moveAtSpecifiedSpeed(double specifiedDistance, int specifiedSpee
       double pwm = speedControl.calculateSpeed(specifiedSpeed, pidForSpeed.Kp, pidForSpeed.Ki,
                                                pidForSpeed.Kd);
       setPwmValue(static_cast<int>(-std::abs(pwm)));
+      controller.tslpTsk(4);
     }
   } else {
     while(hasArrived(goalDistance, true)) {
       double pwm = speedControl.calculateSpeed(specifiedSpeed, pidForSpeed.Kp, pidForSpeed.Ki,
                                                pidForSpeed.Kd);
       setPwmValue(static_cast<int>(std::abs(pwm)));
+      controller.tslpTsk(4);
     }
   }
   controller.stopMotor();
@@ -85,6 +89,7 @@ void Navigator::moveToSpecifiedColor(Color specifiedColor, int pwm)
     controller.getRawColor(r, g, b);
     // rgb値をhsv値に変換
     controller.convertHsv(r, g, b);
+    controller.tslpTsk(4);
   }
   controller.stopMotor();
 }
@@ -108,5 +113,4 @@ void Navigator::setPwmValue(int pwm, double alpha)
 {
   controller.setRightMotorPwm(pwm + alpha);
   controller.setLeftMotorPwm(pwm - alpha);
-  controller.tslpTsk(4);
 }

--- a/src/module/Navigator.cpp
+++ b/src/module/Navigator.cpp
@@ -30,12 +30,12 @@ void Navigator::move(double specifiedDistance, int pwm, const double pGain)
   if(specifiedDistance < 0) {
     while(hasArrived(goalDistance, false)) {
       double alpha = pid.control(controller.getLeftMotorCount() - controller.getRightMotorCount());
-      setPwmValue(static_cast<int>(-std::abs(pwm)), -alpha);
+      setPwmValue(-std::abs(pwm), -alpha);
     }
   } else {
     while(hasArrived(goalDistance, true)) {
       double alpha = pid.control(controller.getLeftMotorCount() - controller.getRightMotorCount());
-      setPwmValue(static_cast<int>(std::abs(pwm)), -alpha);
+      setPwmValue(std::abs(pwm), -alpha);
     }
   }
 
@@ -63,6 +63,28 @@ void Navigator::moveAtSpecifiedSpeed(double specifiedDistance, int specifiedSpee
                                                pidForSpeed.Kd);
       setPwmValue(static_cast<int>(std::abs(pwm)));
     }
+  }
+  controller.stopMotor();
+}
+
+void Navigator::moveToSpecifiedColor(Color specifiedColor, int pwm)
+{
+  int r = 0;
+  int g = 0;
+  int b = 0;
+
+  // カラーセンサからrgb値を取得
+  controller.getRawColor(r, g, b);
+  // rgb値をhsv値に変換
+  controller.convertHsv(r, g, b);
+
+  // 特定の色まで移動する
+  while(controller.hsvToColor(controller.getHsv()) != specifiedColor) {
+    setPwmValue(pwm);
+    // カラーセンサからrgb値を取得
+    controller.getRawColor(r, g, b);
+    // rgb値をhsv値に変換
+    controller.convertHsv(r, g, b);
   }
   controller.stopMotor();
 }

--- a/src/module/Navigator.h
+++ b/src/module/Navigator.h
@@ -58,6 +58,15 @@ class Navigator {
    */
   void moveAtSpecifiedSpeed(double specifiedDistance, int specifiedSpeed);
 
+  /**
+   * 指定した色まで前進と後進をする
+   *
+   * @param specifiedColor [指定する色]
+   * @param pwm [モータの強さ。正なら前進、負なら後進する]
+   * @return なし
+   */
+  void moveToSpecifiedColor(Color specifiedColor, int pwm = 30);
+
  private:
   Distance distance;
   Controller& controller;

--- a/test/NavigatorTest.cpp
+++ b/test/NavigatorTest.cpp
@@ -170,4 +170,23 @@ namespace etrobocon2019_test {
         = distance.getDistance(controller.getLeftMotorCount(), controller.getRightMotorCount());
     ASSERT_LE(end - start, expected);
   }
+
+  TEST(Navigator, moveToSpecifiedColorTest)
+  {
+    Controller controller;
+    Navigator navigator(controller);
+
+    Color expected = Color::black;
+
+    navigator.moveToSpecifiedColor(expected);
+
+    int r = 0;
+    int g = 0;
+    int b = 0;
+    controller.getRawColor(r, g, b);
+    controller.convertHsv(r, g, b);
+    Color actual = controller.hsvToColor(controller.getHsv());
+
+    ASSERT_EQ(expected, actual);
+  }
 }  // namespace etrobocon2019_test

--- a/test/dummy/Controller.h
+++ b/test/dummy/Controller.h
@@ -80,7 +80,7 @@ class Controller {
     }
     return false;
   };
-  void getRawColor(std::uint16_t& r, std::uint16_t& g, std::uint16_t& b)
+  void getRawColor(int& r, int& g, int& b)
   {
     r = mock_r;
     g = mock_g;


### PR DESCRIPTION
### 変更点
`Navigator.moveToSpecifiedColor`を追加
それに伴いテストコードを追加
`test/dummy/Controller.h`を修正

### 実機テストの結果（実機テストが必要な場合）
 - ガレージ手前から走行し、ガレージ前の黒線を認識すると停止できた
 - ほかの色も試してみたところ、違う色で止まることが多々あった

### 問題点
 - 赤と黄色、黒と青を誤って識別することがあった
 - また、ほかの色を指定しているのに黒と白の中間で停止することがあった
 - 色識別がうまくいっていないと考えられる