### PR TITLE
closed #145 カメラシステムを使う場合と使わない場合で切り替えられるようにする

### DIFF
--- a/src/module/Calibrator.cpp
+++ b/src/module/Calibrator.cpp
@@ -147,7 +147,7 @@ int Calibrator::averageBrightness()
   return meanBrightness / times;
 }
 
-bool Calibrator::useCameraSystem() const
+bool Calibrator::getCameraMode() const
 {
   return isCameraMode;
 }

--- a/src/module/Calibrator.cpp
+++ b/src/module/Calibrator.cpp
@@ -6,13 +6,23 @@
 #include "Calibrator.h"
 
 Calibrator::Calibrator(Controller& controller_)
-  : controller(controller_), isLeft(true), brightnessOfWhite(0), brightnessOfBlack(0)
+  : controller(controller_),
+    isCameraMode(true),
+    isLeft(true),
+    brightnessOfWhite(0),
+    brightnessOfBlack(0)
 {
 }
 
 bool Calibrator::calibration()
 {
   Display::print(2, "now calibration...");
+
+  if(!setCameraMode()) {
+    Display::print(2, "Error setCameraMode!");
+    return false;
+  }
+
   if(!setLRCourse()) {
     Display::print(2, "Error setLRCourse!");
     return false;
@@ -28,9 +38,35 @@ bool Calibrator::calibration()
     return false;
   }
 
-  Display::print(4, "White: %3d", brightnessOfWhite);
-  Display::print(5, "Black: %3d", brightnessOfBlack);
+  Display::print(5, "White: %3d", brightnessOfWhite);
+  Display::print(6, "Black: %3d", brightnessOfBlack);
 
+  return true;
+}
+
+bool Calibrator::setCameraMode()
+{
+  char cameraMode[8] = "ON";
+
+  controller.tslpTsk(500);
+  while(!controller.buttonIsPressedEnter()) {
+    if(isCameraMode) {
+      std::strcpy(cameraMode, "ON");
+    } else {
+      std::strcpy(cameraMode, "OFF");
+    }
+    Display::print(3, "camera system: %s ?", cameraMode);
+
+    if(controller.buttonIsPressedLeft() || controller.buttonIsPressedRight()) {
+      isCameraMode = !isCameraMode;
+      controller.speakerPlayToneFS6(50);
+      controller.tslpTsk(500);
+    }
+    controller.tslpTsk(4);
+  }
+  Display::print(3, "camera system: %s", cameraMode);
+
+  controller.speakerPlayToneFS6(100);
   return true;
 }
 
@@ -45,7 +81,7 @@ bool Calibrator::setLRCourse()
     } else {
       std::strcpy(course, "Right");
     }
-    Display::print(3, "Set LRCourse: %s ?", course);
+    Display::print(4, "Set LRCourse: %s ?", course);
 
     if(controller.buttonIsPressedLeft() || controller.buttonIsPressedRight()) {
       isLeft = !isLeft;
@@ -54,7 +90,7 @@ bool Calibrator::setLRCourse()
     }
     controller.tslpTsk(4);
   }
-  Display::print(3, "course: %s", course);
+  Display::print(4, "course: %s", course);
 
   controller.speakerPlayToneFS6(100);
   return true;
@@ -82,7 +118,7 @@ bool Calibrator::setBrightness(Brightness brightness)
     }
 
     int tmpColor = controller.getBrightness();
-    Display::print(4, "Set brightness of %s: %3d ?", name, tmpColor);
+    Display::print(5, "Set brightness of %s: %3d ?", name, tmpColor);
 
     controller.tslpTsk(4);
   }

--- a/src/module/Calibrator.cpp
+++ b/src/module/Calibrator.cpp
@@ -147,14 +147,21 @@ int Calibrator::averageBrightness()
   return meanBrightness / times;
 }
 
+bool Calibrator::useCameraSystem() const
+{
+  return isCameraMode;
+}
+
 bool Calibrator::isLeftCourse() const
 {
   return isLeft;
 }
+
 int Calibrator::getWhiteBrightness() const
 {
   return brightnessOfWhite;
 };
+
 int Calibrator::getBlackBrightness() const
 {
   return brightnessOfBlack;

--- a/src/module/Calibrator.h
+++ b/src/module/Calibrator.h
@@ -26,7 +26,7 @@ class Calibrator {
   /** カメラシステムを使用するかどうかを判断する。
    * @return Lカメラシステムを使用するかどうかの真偽値（Trueなら使用する）
    */
-  bool useCameraSystem() const;
+  bool getCameraMode() const;
 
   /** Leftコースであるかどうかを判断する。
    * @return Leftコースであるかどうかの真偽値（TrueならLeftコース）

--- a/src/module/Calibrator.h
+++ b/src/module/Calibrator.h
@@ -23,6 +23,11 @@ class Calibrator {
    */
   bool calibration();
 
+  /**
+   *
+   */
+  bool setCameraMode();
+
   /** Leftコースであるかどうかを判断する。
    * @return Leftコースであるかどうかの真偽値（TrueならLeftコース）
    */
@@ -51,6 +56,7 @@ class Calibrator {
 
  private:
   Controller& controller;
+  bool isCameraMode;
   bool isLeft;  // Leftコースであるかどうかの真偽値（TrueならLeftコース）
   unsigned int brightnessOfWhite;  // 白色の明るさ
   unsigned int brightnessOfBlack;  // 黒色の明るさ

--- a/src/module/Calibrator.h
+++ b/src/module/Calibrator.h
@@ -23,10 +23,10 @@ class Calibrator {
    */
   bool calibration();
 
-  /**
-   *
+  /** カメラシステムを使用するかどうかを判断する。
+   * @return Lカメラシステムを使用するかどうかの真偽値（Trueなら使用する）
    */
-  bool setCameraMode();
+  bool useCameraSystem() const;
 
   /** Leftコースであるかどうかを判断する。
    * @return Leftコースであるかどうかの真偽値（TrueならLeftコース）
@@ -43,6 +43,11 @@ class Calibrator {
    */
   int getBlackBrightness() const;
 
+  /** カメラシステムを使用するかどうかを設定する
+   * @return 正常終了したかどうかの真偽値(Trueなら正常終了)
+   */
+  bool setCameraMode();
+
   /** LコースかRコースかを設定する。
    * @return 正常終了したかどうかの真偽値（Trueなら正常終了）
    */
@@ -56,8 +61,8 @@ class Calibrator {
 
  private:
   Controller& controller;
-  bool isCameraMode;
-  bool isLeft;  // Leftコースであるかどうかの真偽値（TrueならLeftコース）
+  bool isCameraMode;  // カメラシステムを使用するかどうか(Trueなら使用する)
+  bool isLeft;        // Leftコースであるかどうかの真偽値（TrueならLeftコース）
   unsigned int brightnessOfWhite;  // 白色の明るさ
   unsigned int brightnessOfBlack;  // 黒色の明るさ
 

--- a/test/CalibratorTest.cpp
+++ b/test/CalibratorTest.cpp
@@ -21,9 +21,58 @@ namespace etrobocon2019_test {
     Controller con;
     Calibrator calibrator(con);
 
+    ASSERT_EQ(calibrator.getCameraMode(), true);
     ASSERT_EQ(calibrator.isLeftCourse(), true);
     ASSERT_EQ(calibrator.getWhiteBrightness(), 0);
     ASSERT_EQ(calibrator.getBlackBrightness(), 0);
+  }
+
+  TEST(Calibrator, setCameraModeTest1)
+  {
+    Controller con;
+
+    Calibrator calibrator(con);
+
+    calibrator.setCameraMode();
+
+    ASSERT_EQ(calibrator.getCameraMode(), true);
+  }
+
+  TEST(Calibrator, setCameraModeTest2)
+  {
+    Controller con;
+
+    Calibrator calibrator(con);
+
+    con.pushRight = true;
+    calibrator.setCameraMode();
+
+    ASSERT_EQ(calibrator.getCameraMode(), false);
+  }
+
+  TEST(Calibrator, setCameraModeTest3)
+  {
+    Controller con;
+
+    Calibrator calibrator(con);
+
+    con.pushLeft = true;
+    calibrator.setCameraMode();
+
+    ASSERT_EQ(calibrator.getCameraMode(), false);
+  }
+
+  TEST(Calibrator, setCameraModeTest4)
+  {
+    Controller con;
+
+    Calibrator calibrator(con);
+
+    con.pushLeft = true;
+    con.pushRight = true;
+    calibrator.setCameraMode();
+
+    ASSERT_EQ(calibrator.getCameraMode(), true);
   }
 
   TEST(Calibrator, setLRCourseTest1)


### PR DESCRIPTION
### 変更点
Calibratorクラスに以下を追加しました。
- カメラシステムを使う・使わないを表すメンバ変数`isCameraMode`
- ディスプレイ上でカメラシステムを使う・使わないを選択するメンバ関数`setCameraMode`
- メンバ変数`isCameraMode`のgetter`getCameraMode` 

もっと良い変数名・関数名があったら教えてください。

![IMG_4208](https://user-images.githubusercontent.com/46063788/60753654-0200b600-a011-11e9-9841-2604ff6b5b97.JPG)
![IMG_4209](https://user-images.githubusercontent.com/46063788/60753656-05943d00-a011-11e9-93ee-7cb47ba0ba9d.JPG)
