### PR TITLE
closed #171 ブロックビンゴエリアとガレージでLRに応じて処理の切り替えができる

### DIFF
--- a/src/module/EtRobocon2019.cpp
+++ b/src/module/EtRobocon2019.cpp
@@ -1,4 +1,5 @@
 #include "EtRobocon2019.h"
+#include "BlockBingo.h"
 #include "Controller.h"
 #include "Calibrator.h"
 #include "Display.h"
@@ -25,15 +26,15 @@ void EtRobocon2019::start()
   // NormalCourseを走り出す．
   normalCourse.runNormalCourse();
 
-
   // ブロックビンゴ
-
+  BlockBingo blockBingo(controller);
+  // ここでビンゴを開始するblockBingoのメンバ関数を呼び出す
 
   // ガレージ
   Parking parking(controller);
-  if(isLeftCourse){
+  if(isLeftCourse) {
     parking.parkAtAL();
-  }else{
+  } else {
     parking.parkAtAR();
   }
 }

--- a/src/module/EtRobocon2019.cpp
+++ b/src/module/EtRobocon2019.cpp
@@ -4,6 +4,7 @@
 #include "Display.h"
 #include "NormalCourse.h"
 #include "Navigator.h"
+#include "Parking.h"
 
 void EtRobocon2019::start()
 {
@@ -23,4 +24,16 @@ void EtRobocon2019::start()
   NormalCourse normalCourse(controller, isLeftCourse, targetBrightness);
   // NormalCourseを走り出す．
   normalCourse.runNormalCourse();
+
+
+  // ブロックビンゴ
+
+
+  // ガレージ
+  Parking parking(controller);
+  if(isLeftCourse){
+    parking.parkAtAL();
+  }else{
+    parking.parkAtAR();
+  }
 }


### PR DESCRIPTION
### 変更点
EtRobocon2019クラスのノーマルコース走行の後に、以下の処理を追加しました。
- BlockBingoクラスのインスタンス化
- isLeftCourseがTrueの場合、ParkingクラスのparkAtAL関数を呼び出す
- isLeftCourseがFalseの場合、ParkingクラスのparkAtAR関数を呼び出す

BlockBingoクラスが持つであろう「ブロックビンゴを開始する関数」は未実装のため、これを呼び出す処理は追加していません。

また、ブロックビンゴエリアでは走行体はカメラシステムからの指示通りに動くだけなので、BlockBingoクラスがisLeftCourseを受け取る必要はないと考えました。

### 実機テストの結果（実機テストが必要な場合）
ノーマルコースをゴールした後、コースに応じたガレージ駐車の処理をすることを確認しました。