### PR TITLE
closed #199 ビンゴを飛ばし、ガレージ駐車まで行うクラスの作成

### DIFF
--- a/src/Makefile.inc
+++ b/src/Makefile.inc
@@ -17,7 +17,8 @@ APPL_CXXOBJS += \
     Rotation.o \
     Bluetooth.o \
     BlockBingo.o \
-    Parking.o
+    Parking.o \
+    MoveDirectGarage.o
 
 SRCLANG := c++
 

--- a/src/module/MoveDirectGarage.cpp
+++ b/src/module/MoveDirectGarage.cpp
@@ -1,0 +1,83 @@
+/**
+ *  @file   MoveDirectGarage
+ *  @brief  ビンゴを行わずにガレージに向かうクラス
+ *  @author match97
+ */
+
+//このクラスが使用されないことを願う
+
+#include "MoveDirectGarage.h"
+
+MoveDirectGarage::MoveDirectGarage(Controller &controller_) : controller(controller_) {}
+
+void MoveDirectGarage::MoveDirectGarageL()
+{
+    Navigator navigator(controller);
+
+    //ブロックを押す
+    navigator.moveToSpecifiedColor(Color::yellow, 10);   
+    navigator.move(-60, 10, 0.6);
+    navigator.spin(45.0,false);
+    navigator.moveToSpecifiedColor(Color::black, 15);
+    //4のとこ
+    navigator.moveToSpecifiedColor(Color::white, 15);    
+    navigator.moveToSpecifiedColor(Color::black, 15);
+    navigator.move(30, 10, 0.6);
+    navigator.spin(45.0,true);
+    //ブロックを押す
+    navigator.moveToSpecifiedColor(Color::red, 10);
+    navigator.move(-60, 10, 0.6);
+    navigator.spin(45.0,true);
+    navigator.moveToSpecifiedColor(Color::black, 15);
+    navigator.move(65, 10, 0.6);
+    navigator.spin(45.0,false);
+    //真ん中
+    navigator.moveToSpecifiedColor(Color::white, 15);
+    navigator.moveToSpecifiedColor(Color::black, 15);
+    navigator.moveToSpecifiedColor(Color::white, 15);
+    navigator.move(30, 10, 0.6);
+    navigator.spin(90.0,true);
+    navigator.moveToSpecifiedColor(Color::green, 10);
+    navigator.move(-60, 8, 0.6);
+    navigator.spin(45.0,false);
+    //５のとこ
+    navigator.moveToSpecifiedColor(Color::black, 15);
+    navigator.moveToSpecifiedColor(Color::white, 15);
+    navigator.move(20, 10, 0.6);
+    navigator.spin(45.0,false);
+    //以下はparkingクラスを使用
+
+}
+
+void MoveDirectGarage::MoveDirectGarageR()
+{
+    Navigator navigator(controller);
+
+    navigator.moveToSpecifiedColor(Color::yellow, 10);
+    //5のとこ
+    navigator.move(100, 10, 0.6);
+    navigator.moveToSpecifiedColor(Color::black, 10);
+    navigator.moveToSpecifiedColor(Color::yellow, 10);
+    navigator.move(-60, 10, 0.6);
+    navigator.spin(45.0,true);
+    navigator.moveToSpecifiedColor(Color::black, 10);
+    navigator.move(60, 10, 0.6);
+    navigator.spin(45.0,false);
+    //真ん中
+    navigator.moveToSpecifiedColor(Color::white, 10);
+    navigator.moveToSpecifiedColor(Color::black, 10);
+    navigator.moveToSpecifiedColor(Color::white, 10);
+    navigator.move(30, 10, 0.6);
+    navigator.spin(90.0,true);
+    navigator.moveToSpecifiedColor(Color::blue, 10);
+    navigator.move(-60, 10, 0.6);
+    navigator.spin(45.0,false);
+    //4のとこ
+    navigator.moveToSpecifiedColor(Color::white, 10);
+    navigator.moveToSpecifiedColor(Color::black, 10);
+    navigator.moveToSpecifiedColor(Color::white, 10);
+    navigator.move(30, 10, 0.6);
+    navigator.spin(45.0,false);
+    //以下はparkingクラスを使用
+
+}

--- a/src/module/MoveDirectGarage.cpp
+++ b/src/module/MoveDirectGarage.cpp
@@ -10,7 +10,7 @@
 
 MoveDirectGarage::MoveDirectGarage(Controller &controller_) : controller(controller_) {}
 
-void MoveDirectGarage::MoveDirectGarageL()
+void MoveDirectGarage::moveDirectGarageL()
 {
     Navigator navigator(controller);
 
@@ -49,7 +49,7 @@ void MoveDirectGarage::MoveDirectGarageL()
 
 }
 
-void MoveDirectGarage::MoveDirectGarageR()
+void MoveDirectGarage::moveDirectGarageR()
 {
     Navigator navigator(controller);
 

--- a/src/module/MoveDirectGarage.h
+++ b/src/module/MoveDirectGarage.h
@@ -1,0 +1,31 @@
+/**
+ *  @file   MoveDirectGarage
+ *  @brief  ビンゴを行わずにガレージに向かうクラス
+ *  @author match97
+ */
+#ifndef MOVEDIRECTGARAGE_H
+#define MOVEDIRECTGARAGE_H
+
+#include "Controller.h"
+#include "Navigator.h"
+
+class MoveDirectGarage {
+    private:
+      Controller controller;
+
+    public:
+      /**
+       * コンストラクタ
+       */
+      MoveDirectGarage(Controller &controller_);
+      /**
+       * Lコースのガレージに直接向かう
+       */
+      void MoveDirectGarageL();
+      /**
+       *  Rコースのガレージに直接向かう
+       **/
+      void MoveDirectGarageR();
+};
+
+#endif

--- a/src/module/MoveDirectGarage.h
+++ b/src/module/MoveDirectGarage.h
@@ -21,11 +21,11 @@ class MoveDirectGarage {
       /**
        * Lコースのガレージに直接向かう
        */
-      void MoveDirectGarageL();
+      void moveDirectGarageL();
       /**
        *  Rコースのガレージに直接向かう
        **/
-      void MoveDirectGarageR();
+      void moveDirectGarageR();
 };
 
 #endif

--- a/src/module/Parking.cpp
+++ b/src/module/Parking.cpp
@@ -2,6 +2,7 @@
  * @file Parking.cpp
  * @brief ガレージ駐車に使用するクラス
  * @author Oiwane
+ * updated by match97
  */
 #include "Parking.h"
 
@@ -14,12 +15,12 @@ void Parking::parkAtAL()
   navigator.moveToSpecifiedColor(Color::green, 10);
   controller.speakerPlayToneFS6(100);
   navigator.move(100, 10, 0.6);
-  controller.speakerPlayToneFS6(100);
+  navigator.spin(10.0, false);
   navigator.moveToSpecifiedColor(Color::blue, 10);
+  navigator.spin(10.0, true);
   controller.speakerPlayToneFS6(100);
   navigator.move(300, 10, 0.6);
-  controller.speakerPlayToneFS6(100);
-  navigator.spin(90.0);
+  navigator.spin(90.0, false);
 
   this->stopFor3sec();
 }
@@ -29,25 +30,14 @@ void Parking::parkAtAR()
   Navigator navigator(controller);
 
   navigator.moveToSpecifiedColor(Color::blue, 10);
-  controller.speakerPlayToneFS6(100);
   navigator.move(250, 10, 0.6);
-  controller.speakerPlayToneFS6(100);
-  navigator.spin(90, false);
-  controller.speakerPlayToneFS6(100);
+  navigator.spin(45, false);
   navigator.moveToSpecifiedColor(Color::black, 10);
-  controller.speakerPlayToneFS6(100);
-  navigator.move(50, 10, 0.6);
-  controller.speakerPlayToneFS6(100);
-  navigator.spin(90);
-  controller.speakerPlayToneFS6(100);
-  navigator.moveToSpecifiedColor(Color::black, 10);
-  controller.speakerPlayToneFS6(100);
+  navigator.move(40, 10, 0.6);
+  navigator.spin(45, true);
   navigator.moveToSpecifiedColor(Color::blue, 10);
-  controller.speakerPlayToneFS6(100);
   navigator.move(125, 10, 0.6);
-  controller.speakerPlayToneFS6(100);
   navigator.spin(90, false);
-  controller.speakerPlayToneFS6(100);
   navigator.move(400, 10, 0.6);
 
   this->stopFor3sec();

--- a/src/module/Parking.cpp
+++ b/src/module/Parking.cpp
@@ -13,12 +13,10 @@ void Parking::parkAtAL()
   Navigator navigator(controller);
 
   navigator.moveToSpecifiedColor(Color::green, 10);
-  controller.speakerPlayToneFS6(100);
   navigator.move(100, 10, 0.6);
   navigator.spin(10.0, false);
   navigator.moveToSpecifiedColor(Color::blue, 10);
   navigator.spin(10.0, true);
-  controller.speakerPlayToneFS6(100);
   navigator.move(300, 10, 0.6);
   navigator.spin(90.0, false);
 

--- a/test/MoveDirectGarageTest.cpp
+++ b/test/MoveDirectGarageTest.cpp
@@ -14,4 +14,17 @@ namespace etrobocon2019_test {
     MoveDirectGarage moveDirectGarage(controller);
   }
 
+  TEST(MoveDirectGarage, MoveDirectGarageTest_init)
+  {
+    Controller controller;
+    MoveDirectGarage moveDirectGarageR();
+  }
+
+  TEST(MoveDirectGarage, MoveDirectGarageTest_init)
+  {
+    Controller controller;
+    MoveDirectGarage moveDirectGarageL();
+  }
+
+
 }  // namespace etrobocon2019_test

--- a/test/MoveDirectGarageTest.cpp
+++ b/test/MoveDirectGarageTest.cpp
@@ -1,0 +1,17 @@
+/**
+ *  @file   MoveDirectGarageTest.cpp
+ *  @brief  MoveDirectGarageクラスのテストファイル
+ *  @author match97
+ */
+#include <gtest/gtest.h>
+#include "MoveDirectGarage.h"
+
+namespace etrobocon2019_test {
+
+  TEST(MoveDirectGarage, MoveDirectGarageTest_init)
+  {
+    Controller controller;
+    MoveDirectGarage moveDirectGarage(controller);
+  }
+
+}  // namespace etrobocon2019_test

--- a/test/MoveDirectGarageTest.cpp
+++ b/test/MoveDirectGarageTest.cpp
@@ -14,15 +14,19 @@ namespace etrobocon2019_test {
     MoveDirectGarage moveDirectGarage(controller);
   }
 
-  TEST(MoveDirectGarage, MoveDirectGarageTest_init)
+  TEST(MoveDirectGarage, MoveDirectGarageRTest)
   {
     Controller controller;
+    MoveDirectGarage moveDirectGarage(controller);
+
     MoveDirectGarage moveDirectGarageR();
   }
 
-  TEST(MoveDirectGarage, MoveDirectGarageTest_init)
+  TEST(MoveDirectGarage, MoveDirectGarageLTest)
   {
     Controller controller;
+    MoveDirectGarage moveDirectGarage(controller);
+
     MoveDirectGarage moveDirectGarageL();
   }
 


### PR DESCRIPTION
### 変更点
- 進入ラインからビンゴを無視してガレージ駐車まで行うクラスの作成
- ブロックを避けつつ移動するように作成する
- L,Rコース版を作る
- parkingクラス内の処理が一つ終わるごとに音が鳴ってかっこ悪かったので削除
- parkingクラスの軽微な変更(L,Rコース)

### parkingクラスのLコースの変更点
今までのだと⑧の右上の緑サークルの下半分の緑を認識しまっすぐ進むと、ガレージ前の青線が認識できないことあった。
緑を認識後、少し進み10度反時計回りに回頭することにより緑サークルの下半分を認識した場合でも確実にその青線を認識可能に変更した。

### parkingクラスのRコースの変更点
今までは④の左上の青サークルを認識後少し進んで90度反時計回りに回頭し、ガレージ前の黒線を認識後し90度時計回りに回頭していたが、青サークルの認識場所によっては一回目の回頭場所がずれ黒線を認識しない場合があった。
一回目の回頭を45度反時計回りの回頭にすることにより、一回目の回頭場所がずれても確実にガレージ前の黒線を認識するように変更した。

### 実機テストの結果（実機テストが必要な場合）
 - Rコース
https://photos.app.goo.gl/rHJzysaoBzVymzi18
- Lコース
https://photos.app.goo.gl/HjWxo2AmrAcrF5NG8

- 初期位置は進入ライン上の黒線の真ん中
### これがあればいいな
- 光センサーの角度によって成功率が違うので、角度を初期位置調整するクラス
- 黒線を認識しまっすぐ走るクラス