### PR TITLE
循環バッファを用いて色識別の多数決をまともなものにした（3〜4%）

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -101,6 +101,27 @@
         "type_traits": "cpp",
         "tuple": "cpp",
         "typeinfo": "cpp",
-        "utility": "cpp"
+        "utility": "cpp",
+        "csignal": "cpp",
+        "atomic": "cpp",
+        "strstream": "cpp",
+        "bitset": "cpp",
+        "complex": "cpp",
+        "condition_variable": "cpp",
+        "forward_list": "cpp",
+        "list": "cpp",
+        "unordered_set": "cpp",
+        "algorithm": "cpp",
+        "iterator": "cpp",
+        "map": "cpp",
+        "memory_resource": "cpp",
+        "numeric": "cpp",
+        "random": "cpp",
+        "set": "cpp",
+        "string": "cpp",
+        "mutex": "cpp",
+        "thread": "cpp",
+        "cfenv": "cpp",
+        "typeindex": "cpp"
     }
 }

--- a/src/app.cfg
+++ b/src/app.cfg
@@ -5,6 +5,7 @@ INCLUDE("app_common.cfg");
 DOMAIN(TDOM_APP) {
 CRE_TSK(MAIN_TASK, { TA_ACT , 0, main_task, TMIN_APP_TPRI + 1, STACK_SIZE  * 10 , NULL });
 CRE_TSK(BT_TASK, { TA_ACT , 0, bt_task, TMIN_APP_TPRI + 2, STACK_SIZE, NULL });
+CRE_TSK(COLOR_TASK, { TA_ACT , 0, color_task, TMIN_APP_TPRI + 3, STACK_SIZE, NULL });
 }
 
 ATT_MOD("app.o");

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -7,7 +7,7 @@
 // 演習用のユーティリティ
 std::array<char, 256> Bluetooth::commands;
 bool Bluetooth::is_start = false;
-std::array<Color, 10> Controller::color_buffer;
+std::array<Color, 10> Controller::color_buffer = { Color::black };
 int Controller::color_buffer_counter = 0;
 
 /**
@@ -26,6 +26,16 @@ void main_task(intptr_t unused)
   ext_tsk();
 }
 // end::main_task_2[]
+
+void color_task(intptr_t unused)
+{
+  Controller controller;
+  while(true) {
+    controller.registerColor();
+    controller.tslpTsk(4);
+  }
+  ext_tsk();
+}
 
 void bt_task(intptr_t unused)
 {
@@ -75,11 +85,6 @@ void bt_task(intptr_t unused)
   Bluetooth::commands = commands;
   command_string[i + 1] = '\0';
   Display::print(10, "Commands: %-10s", command_string);
-
-  while(true){
-    controller.registerColor();
-    controller.tslpTsk(4);
-  }
 
   ext_tsk();
 }

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -1,11 +1,14 @@
 #include "app.h"
 #include "EtRobocon2019.h"
 #include "Bluetooth.h"
+#include "Controller.h"
 #include <array>
 
 // 演習用のユーティリティ
 std::array<char, 256> Bluetooth::commands;
 bool Bluetooth::is_start = false;
+std::array<Color, 10> Controller::color_buffer;
+int Controller::color_buffer_counter = 0;
 
 /**
  * メインタスク
@@ -38,7 +41,7 @@ void bt_task(intptr_t unused)
       bluetooth.serialSend(1);
       break;
     }
-    tslp_tsk(4);
+    controller.tslpTsk(4);
   }
   Display::print(12, "success: connect BT");
   bluetooth.flush();
@@ -67,10 +70,16 @@ void bt_task(intptr_t unused)
       break;
     }
     command_string[i] = commands[i] = receiveCommand;
-    tslp_tsk(4);
+    controller.tslpTsk(4);
   }
   Bluetooth::commands = commands;
   command_string[i + 1] = '\0';
   Display::print(10, "Commands: %-10s", command_string);
+
+  while(true){
+    controller.registerColor();
+    controller.tslpTsk(4);
+  }
+
   ext_tsk();
 }

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -7,8 +7,8 @@
 // 演習用のユーティリティ
 std::array<char, 256> Bluetooth::commands;
 bool Bluetooth::is_start = false;
-std::array<Color, 10> Controller::color_buffer = { Color::black };
-int Controller::color_buffer_counter = 0;
+std::array<Color, 10> Controller::colorBuffer = { Color::black };
+int Controller::colorBufferCounter = 0;
 
 /**
  * メインタスク

--- a/src/app.h
+++ b/src/app.h
@@ -14,6 +14,7 @@ extern "C" {
 
 extern void main_task(intptr_t exinf);
 extern void bt_task(intptr_t exinf);
+extern void color_task(intptr_t exinf);
 
 #endif /* TOPPERS_MACRO_ONLY */
 

--- a/src/module/api/core/Controller.cpp
+++ b/src/module/api/core/Controller.cpp
@@ -178,10 +178,10 @@ Color Controller::getColor(){
 }
 
 void Controller::registerColor(){
-  color_buffer[color_buffer_counter] = getColor();
-  color_buffer_counter++;
-  if(color_buffer_size <= color_buffer_counter){
-    color_buffer_counter = 0;
+  colorBuffer[colorBufferCounter] = getColor();
+  colorBufferCounter++;
+  if(colorBufferSize <= colorBufferCounter){
+    colorBufferCounter = 0;
   }
 }
 
@@ -189,8 +189,8 @@ void Controller::registerColor(){
 Color Controller::determineColor(int colorNum)
 {
   int counter[colorNum] = { 0 };
-  for(int i = 0; i < color_buffer_size; i++) {
-    counter[static_cast<int>(color_buffer[i])]++;
+  for(int i = 0; i < colorBufferSize; i++) {
+    counter[static_cast<int>(colorBuffer[i])]++;
     this->tslpTsk(4);
   }
   int max = 0;

--- a/src/module/api/core/Controller.cpp
+++ b/src/module/api/core/Controller.cpp
@@ -169,18 +169,28 @@ Color Controller::hsvToColor(const HsvStatus& status)
   }
 }
 
+Color Controller::getColor(){
+  int r, g, b;
+  r = g = b = 0;
+  this->getRawColor(r, g, b);
+  this->convertHsv(r, g, b);
+  return this->hsvToColor(this->getHsv());
+}
+
+void Controller::registerColor(){
+  color_buffer[color_buffer_counter] = getColor();
+  color_buffer_counter++;
+  if(color_buffer_size <= color_buffer_counter){
+    color_buffer_counter = 0;
+  }
+}
+
 // 5(determine)回色検出を行い、最も検出された回数が多い色(白以外)を返す関数である
-Color Controller::determineColor(int determineNum, int colorNum)
+Color Controller::determineColor(int colorNum)
 {
-  int counter[colorNum] = { 0 };
-  int r = 0;
-  int g = 0;
-  int b = 0;
-  for(int i = 0; i < determineNum; i++) {
-    this->getRawColor(r, g, b);
-    this->convertHsv(r, g, b);
-    Color color = this->hsvToColor(this->getHsv());
-    counter[static_cast<int>(color)]++;
+  int counter[color_buffer_size] = { 0 };
+  for(int i = 0; i < color_buffer_size; i++) {
+    counter[static_cast<int>(color_buffer[i])]++;
     this->tslpTsk(4);
   }
   int max = 0;

--- a/src/module/api/core/Controller.cpp
+++ b/src/module/api/core/Controller.cpp
@@ -188,7 +188,7 @@ void Controller::registerColor(){
 // 5(determine)回色検出を行い、最も検出された回数が多い色(白以外)を返す関数である
 Color Controller::determineColor(int colorNum)
 {
-  int counter[color_buffer_size] = { 0 };
+  int counter[colorNum] = { 0 };
   for(int i = 0; i < color_buffer_size; i++) {
     counter[static_cast<int>(color_buffer[i])]++;
     this->tslpTsk(4);

--- a/src/module/api/core/Controller.cpp
+++ b/src/module/api/core/Controller.cpp
@@ -185,7 +185,7 @@ void Controller::registerColor(){
   }
 }
 
-// 5(determine)回色検出を行い、最も検出された回数が多い色(白以外)を返す関数である
+// 循環バッファ内の色を集計し、もっとも多い色を返す。
 Color Controller::determineColor(int colorNum)
 {
   int counter[colorNum] = { 0 };

--- a/src/module/api/core/Controller.h
+++ b/src/module/api/core/Controller.h
@@ -63,7 +63,7 @@ class Controller {
   void convertHsv(int& r, int& g, int& b);  // RGBをHSV変換する
   HsvStatus getHsv() const;
   Color hsvToColor(const HsvStatus& status);  // HSVから色を識別する
-  Color determineColor(int colorNum = 6);
+  Color determineColor(int colorNum = 6);  // 多数決によって色を決定する
   static void lcdFillRect(int x, int y, int h);
   static void lcdDrawString(const char* str, int x, int y);
   static void lcdSetFont();

--- a/src/module/api/core/Controller.h
+++ b/src/module/api/core/Controller.h
@@ -79,9 +79,9 @@ class Controller {
   int limitAngle(int angle);
   Color getColor();
   void registerColor();
-  static constexpr int color_buffer_size = 10;
-  static std::array<Color, color_buffer_size> color_buffer;
-  static int color_buffer_counter;
+  static constexpr int colorBufferSize = 10;
+  static std::array<Color, colorBufferSize> colorBuffer;
+  static int colorBufferCounter;
 
   /**
    * アームを動かす

--- a/src/module/api/core/Controller.h
+++ b/src/module/api/core/Controller.h
@@ -8,6 +8,7 @@
 #include "Motor.h"
 #include "TouchSensor.h"
 #include "GyroSensor.h"
+#include <array>
 /*
  * touch_sensor = EV3_PORT_1;
  * sonar_sensor = EV3_PORT_2;
@@ -62,7 +63,7 @@ class Controller {
   void convertHsv(int& r, int& g, int& b);  // RGBをHSV変換する
   HsvStatus getHsv() const;
   Color hsvToColor(const HsvStatus& status);  // HSVから色を識別する
-  Color determineColor(int determineNum = 5, int colorNum = 6);
+  Color determineColor(int colorNum = 6);
   static void lcdFillRect(int x, int y, int h);
   static void lcdDrawString(const char* str, int x, int y);
   static void lcdSetFont();
@@ -76,6 +77,12 @@ class Controller {
   void stopMotor();
   int getAngleOfRotation();
   int limitAngle(int angle);
+  Color getColor();
+  void registerColor();
+  static constexpr int color_buffer_size = 10;
+  static std::array<Color, color_buffer_size> color_buffer;
+  static int color_buffer_counter;
+
   /**
    * アームを動かす
    * @brief countが正の場合、アームを上げる。countが負の場合、アームを下げる。

--- a/test/ControllerTest.cpp
+++ b/test/ControllerTest.cpp
@@ -1,0 +1,39 @@
+/**
+ *  @file   ControllerTest.cpp
+ *  @brief  ライントレーサークラスのテストファイル
+ *  @author korosuke613
+ */
+#include "Controller.h"
+#include <gtest/gtest.h>
+
+namespace etrobocon2019_test {
+  TEST(Controller, color_buffer_only_black)
+  {
+    Controller controller;
+
+    for(int i = 0; i < controller.color_buffer_size; i++) {
+      controller.setMockRgb(0, 0, 0);
+      controller.registerColor();
+    }
+
+    for(const auto& color : controller.color_buffer){
+      ASSERT_EQ(color, Color::black);
+    }
+  }
+  TEST(Controller, color_buffer_black3_white7)
+  {
+    Controller controller;
+
+    for(int i = 0; i < controller.color_buffer_size; i++) {
+      controller.setMockRgb(0, 0, 0);
+      controller.registerColor();
+    }
+
+    for(int i = 0; i < 7; i++) {
+      controller.setMockRgb(255, 255, 255);
+      controller.registerColor();
+    }
+
+    ASSERT_EQ(controller.determineColor(), Color::white);
+  }
+}  // namespace etrobocon2019_test

--- a/test/ControllerTest.cpp
+++ b/test/ControllerTest.cpp
@@ -7,24 +7,24 @@
 #include <gtest/gtest.h>
 
 namespace etrobocon2019_test {
-  TEST(Controller, color_buffer_only_black)
+  TEST(Controller, colorBuffer_only_black)
   {
     Controller controller;
 
-    for(int i = 0; i < controller.color_buffer_size; i++) {
+    for(int i = 0; i < controller.colorBufferSize; i++) {
       controller.setMockRgb(0, 0, 0);
       controller.registerColor();
     }
 
-    for(const auto& color : controller.color_buffer){
+    for(const auto& color : controller.colorBuffer){
       ASSERT_EQ(color, Color::black);
     }
   }
-  TEST(Controller, color_buffer_black3_white7)
+  TEST(Controller, colorBuffer_black3_white7)
   {
     Controller controller;
 
-    for(int i = 0; i < controller.color_buffer_size; i++) {
+    for(int i = 0; i < controller.colorBufferSize; i++) {
       controller.setMockRgb(0, 0, 0);
       controller.registerColor();
     }

--- a/test/dummy/Controller.cpp
+++ b/test/dummy/Controller.cpp
@@ -4,5 +4,5 @@
 
 std::array<char, 256> Bluetooth::commands;
 bool Bluetooth::is_start = false;
-std::array<Color, 10> Controller::color_buffer;
+std::array<Color, 10> Controller::color_buffer = {Color::white};
 int Controller::color_buffer_counter = 0;

--- a/test/dummy/Controller.cpp
+++ b/test/dummy/Controller.cpp
@@ -4,5 +4,5 @@
 
 std::array<char, 256> Bluetooth::commands;
 bool Bluetooth::is_start = false;
-std::array<Color, 10> Controller::color_buffer = {Color::white};
-int Controller::color_buffer_counter = 0;
+std::array<Color, 10> Controller::colorBuffer = {Color::white};
+int Controller::colorBufferCounter = 0;

--- a/test/dummy/Controller.cpp
+++ b/test/dummy/Controller.cpp
@@ -4,3 +4,5 @@
 
 std::array<char, 256> Bluetooth::commands;
 bool Bluetooth::is_start = false;
+std::array<Color, 10> Controller::color_buffer;
+int Controller::color_buffer_counter = 0;

--- a/test/dummy/Controller.h
+++ b/test/dummy/Controller.h
@@ -170,7 +170,7 @@ class Controller {
     }
   }
 
-  // 5(determine)回色検出を行い、最も検出された回数が多い色(白以外)を返す関数である
+// 循環バッファ内の色を集計し、もっとも多い色を返す。
   Color determineColor(int colorNum=6)
   {
     int counter[color_buffer_size] = { 0 };

--- a/test/dummy/Controller.h
+++ b/test/dummy/Controller.h
@@ -71,9 +71,9 @@ class Controller {
   static constexpr int MOTOR_PWM_MAX = 100;
   // モータ入力電圧の最小値
   static constexpr int MOTOR_PWM_MIN = -100;
-  static constexpr int color_buffer_size = 10;
-  static std::array<Color, color_buffer_size> color_buffer;
-  static int color_buffer_counter;
+  static constexpr int colorBufferSize = 10;
+  static std::array<Color, colorBufferSize> colorBuffer;
+  static int colorBufferCounter;
 
   int noteFs6 = 0;
   int noteFs4 = 0;
@@ -173,9 +173,9 @@ class Controller {
 // 循環バッファ内の色を集計し、もっとも多い色を返す。
   Color determineColor(int colorNum=6)
   {
-    int counter[color_buffer_size] = { 0 };
-    for(int i = 0; i < color_buffer_size; i++) {
-      counter[static_cast<int>(color_buffer[i])]++;
+    int counter[colorBufferSize] = { 0 };
+    for(int i = 0; i < colorBufferSize; i++) {
+      counter[static_cast<int>(colorBuffer[i])]++;
       this->tslpTsk(4);
     }
     int max = 0;
@@ -315,10 +315,10 @@ class Controller {
 
   void registerColor()
   {
-    color_buffer[color_buffer_counter] = getColor();
-    color_buffer_counter++;
-    if(color_buffer_size <= color_buffer_counter) {
-      color_buffer_counter = 0;
+    colorBuffer[colorBufferCounter] = getColor();
+    colorBufferCounter++;
+    if(colorBufferSize <= colorBufferCounter) {
+      colorBufferCounter = 0;
     }
   }
 };


### PR DESCRIPTION
### 変更点
循環バッファを用いて色識別の多数決をまともなものにした（3〜4%）

### 実機テストの結果（実機テストが必要な場合）
![image](https://user-images.githubusercontent.com/20027695/66781113-76e76400-ef0d-11e9-83e7-d177f6b4facb.png)
