### PR TITLE
closed #267 アーム調整を手動でもできるようにした

### DIFF
--- a/src/module/Calibrator.cpp
+++ b/src/module/Calibrator.cpp
@@ -13,8 +13,12 @@ Calibrator::Calibrator(Controller& controller_)
 bool Calibrator::calibration()
 {
   Display::print(2, "Adjust the arm position...");
+  Display::print(3, "  Auto: Touch Button");
+  Display::print(4, "  Manual: Enter Button");
   this->setArm();
   Display::print(2, "Calibration...");
+  Display::print(3, "");
+  Display::print(4, "");
 
   if(!setCameraMode()) {
     Display::print(2, "Error setCameraMode!");
@@ -150,6 +154,10 @@ void Calibrator::setArm()
 {
   while(!controller.touchSensor.isPressed()) {
     controller.tslpTsk(4);
+
+    if(controller.buttonIsPressedEnter()){
+      return;
+    }
   }
   controller.moveArm(50);
   controller.stopLiftMotor();


### PR DESCRIPTION
### 変更点
アームの自動調整がうまく行かなかったときのために、キャリブレーションの始めにアームを自動調整するか手動調整するかを選択できるようにした。

### キャリブレーション時のコンソール画面
```
Adjust the arm position...
  Auto: Touch Button
  Manual: Enter Button
```

- 自動調整したい場合はタッチボタンを押す。
- 手動調整したい場合はエンターボタンを押す。