### PR TITLE
closed #289 黒と白以外の色までライントレースする関数を作成した

### DIFF
--- a/src/module/Navigator.cpp
+++ b/src/module/Navigator.cpp
@@ -159,24 +159,14 @@ void Navigator::lineTraceToSpecifiedColor(Color specifiedColor, int pwm, double 
   constexpr int resolution = 3;
   LineTracer lineTracer(controller, targetBrightness, isLeft);
   // 循環バッファーを作成する(最初は、noneで埋めておく)
-  std::array<Color, 2 * resolution + 1> circulation;
+  constexpr int bufferSize = 2 * resolution + 1;
+  std::array<Color, bufferSize> circulation;
   circulation.fill(Color::none);
   unsigned int index = 0;
   int count = 0;  // 指定色が循環バッファに存在する個数
 
   while(count < resolution) {
-    // 循環バッファーにある指定色の個数をリセットする
-    count = 0;
-
-    // 循環バッファーに色情報を格納する
-    if(circulation.size() <= index) index = 0;
-    circulation[index] = controller.getColor();
-    ++index;
-
-    // 循環バッファー内にある指定色の個数を計算する
-    for(const auto& color : circulation) {
-      if(color == specifiedColor) ++count;
-    }
+    count = this->countColorInBuffer<bufferSize>(circulation, index, specifiedColor);
 
     // ライントレースする
     int turnValue = lineTracer.calculateTurnValue(pwm, 0.0, lineTracePGain, 0.0, 0.0);

--- a/src/module/Navigator.h
+++ b/src/module/Navigator.h
@@ -88,13 +88,21 @@ class Navigator {
   void lineTraceToSpecifiedColor(Color specifiedColor, int pwm = 10, double lineTracePGain = 0.6,
                                  bool isLeft = true);
   /**
+   * 黒と白以外のいづれかの色までライントレースする
+   * @param pwm [モーターパワー]
+   * @param lineTracePGain [ライントレースに使用するPゲイン]
+   * @param isLeft [左エッジならture]
+   */
+  void lineTraceExcludingMonochrome(int pwm = 10, double lineTracePGain = 0.6, bool isLeft = true);
+  /**
    * 循環バッファー内にある指定色の個数を計算する
    * @param circulation [循環バッファー]
    * @param index [循環バッファーのインデックス]
    * @param specifiedColor [指定色]
    */
   template <int N>
-  int countColorInBuffer(std::array<Color, N>& circulation, unsigned int& index, Color specifiedColor)
+  int countColorInBuffer(std::array<Color, N>& circulation, unsigned int& index,
+                         Color specifiedColor)
   {
     int count = 0;  // 指定色が循環バッファに存在する個数
 

--- a/src/module/Navigator.h
+++ b/src/module/Navigator.h
@@ -88,6 +88,13 @@ class Navigator {
   void lineTraceToSpecifiedColor(Color specifiedColor, int pwm = 10, double lineTracePGain = 0.6,
                                  bool isLeft = true);
   /**
+   * 黒と白以外のいづれかの色までライントレースする
+   * @param pwm [モーターパワー]
+   * @param lineTracePGain [ライントレースに使用するPゲイン]
+   * @param isLeft [左エッジならture]
+   */
+  void lineTraceExcludingMonochrome(int pwm = 10, double lineTracePGain = 0.6, bool isLeft = true);
+  /**
    * 循環バッファー内にある指定色の個数を計算する
    * @param circulation [循環バッファー]
    * @param index [循環バッファーのインデックス]

--- a/src/module/Navigator.h
+++ b/src/module/Navigator.h
@@ -79,7 +79,7 @@ class Navigator {
                  double lineTracePGain = 0.6, bool isLeft = true);
   /**
    * 指定した色までライントレースする
-   * @brief 黒と白以外の色までP制御でライントレースをする
+   * @brief 黒と白以外の指定した色までP制御でライントレースをする
    * @param specifiedColor [指定する色]
    * @param pwm [モーターパワー]
    * @param lineTracePGain [ライントレースに使用するPゲイン]
@@ -87,6 +87,29 @@ class Navigator {
    */
   void lineTraceToSpecifiedColor(Color specifiedColor, int pwm = 10, double lineTracePGain = 0.6,
                                  bool isLeft = true);
+  /**
+   * 循環バッファー内にある指定色の個数を計算する
+   * @param circulation [循環バッファー]
+   * @param index [循環バッファーのインデックス]
+   * @param specifiedColor [指定色]
+   */
+  template <int N>
+  int countColorInBuffer(std::array<Color, N>& circulation, unsigned int& index, Color specifiedColor)
+  {
+    int count = 0;  // 指定色が循環バッファに存在する個数
+
+    // 循環バッファーに色情報を格納する
+    if(circulation.size() <= index) index = 0;
+    circulation[index] = controller.getColor();
+    ++index;
+
+    // 循環バッファー内にある指定色の個数を計算する
+    for(const auto& color : circulation) {
+      if(color == specifiedColor) ++count;
+    }
+
+    return count;
+  }
 
  private:
   Distance distance;


### PR DESCRIPTION
### チェックリスト
- [x] clang-formatした
- [x] コーディング規約に準じている
- [x] テストに通った

### 変更点
- Navigatorクラスに `lineTraceExcludingMonochrome` 関数を作成した
- 循環バッファーの中の指定色を数える関数を抽出した
- テストコードは黒以外の識別があるので書いていません

### 実機テストの結果
- うまい具合にまっすぐ入っていけば途中で止まりません。**要調整です**

