### PR TITLE
closed #305 コマンド受信に失敗した場合、ガレージに直行するようにした

### DIFF
--- a/src/module/EtRobocon2019.cpp
+++ b/src/module/EtRobocon2019.cpp
@@ -42,7 +42,6 @@ void EtRobocon2019::start()
     //直接ガレージに移動する
     MoveDirectGarage moveDirectGarage(controller, targetBrightness);
     if(isLeftCourse) {
-      //ブロックビンゴを実行する処理を記述
       moveDirectGarage.moveDirectGarageL();
     } else {
       moveDirectGarage.moveDirectGarageR();

--- a/src/module/EtRobocon2019.cpp
+++ b/src/module/EtRobocon2019.cpp
@@ -43,6 +43,7 @@ void EtRobocon2019::start()
     MoveDirectGarage moveDirectGarage(controller, targetBrightness);
     if(isLeftCourse) {
       //ブロックビンゴを実行する処理を記述
+      moveDirectGarage.moveDirectGarageL();
     } else {
       moveDirectGarage.moveDirectGarageR();  // Rコースの場合はビンゴを行わずにガレージ駐車を行う
     }

--- a/src/module/EtRobocon2019.cpp
+++ b/src/module/EtRobocon2019.cpp
@@ -45,7 +45,7 @@ void EtRobocon2019::start()
       //ブロックビンゴを実行する処理を記述
       moveDirectGarage.moveDirectGarageL();
     } else {
-      moveDirectGarage.moveDirectGarageR();  // Rコースの場合はビンゴを行わずにガレージ駐車を行う
+      moveDirectGarage.moveDirectGarageR();
     }
   }
   // ガレージ

--- a/src/module/EtRobocon2019.cpp
+++ b/src/module/EtRobocon2019.cpp
@@ -30,19 +30,23 @@ void EtRobocon2019::start()
   // NormalCourseを走り出す．
   normalCourse.runNormalCourse();
 
-  // ブロックビンゴ
-  BlockBingo blockBingo(controller, targetBrightness);
-  // ここでビンゴを開始するblockBingoのメンバ関数を呼び出す
-  blockBingo.execOrder<256>(Bluetooth::commands);
-
-  //直接ガレージに移動する
-  MoveDirectGarage moveDirectGarage(controller, targetBrightness);
-  if(isLeftCourse) {
-    //ブロックビンゴを実行する処理を記述
+  // 受信コマンドがあればブロックビンゴを解く。なければ、直接ガレージに進む。
+  if(Bluetooth::commands.size() != 0) {
+    // 受信コマンドがある場合
+    // ブロックビンゴ
+    BlockBingo blockBingo(controller, targetBrightness);
+    // ここでビンゴを開始するblockBingoのメンバ関数を呼び出す
+    blockBingo.execOrder<256>(Bluetooth::commands);
   } else {
-    moveDirectGarage.moveDirectGarageR();  // Rコースの場合はビンゴを行わずにガレージ駐車を行う
+    // 受信コマンドがない場合
+    //直接ガレージに移動する
+    MoveDirectGarage moveDirectGarage(controller, targetBrightness);
+    if(isLeftCourse) {
+      //ブロックビンゴを実行する処理を記述
+    } else {
+      moveDirectGarage.moveDirectGarageR();  // Rコースの場合はビンゴを行わずにガレージ駐車を行う
+    }
   }
-
   // ガレージ
   Parking parking(controller, targetBrightness);
   if(isLeftCourse) {

--- a/src/module/EtRobocon2019.cpp
+++ b/src/module/EtRobocon2019.cpp
@@ -47,7 +47,6 @@ void EtRobocon2019::start()
     } else {
       moveDirectGarage.moveDirectGarageR();
     }
-    return 0;
   }
   // ガレージ
   Parking parking(controller, targetBrightness);

--- a/src/module/EtRobocon2019.cpp
+++ b/src/module/EtRobocon2019.cpp
@@ -47,6 +47,7 @@ void EtRobocon2019::start()
     } else {
       moveDirectGarage.moveDirectGarageR();
     }
+    return 0;
   }
   // ガレージ
   Parking parking(controller, targetBrightness);


### PR DESCRIPTION
### チェックリスト
- [x] clang-formatした
- [x] コーディング規約に準じている
- [x] テストに通った

### 変更点
- コマンド配列のサイズが0なら、ガレージに直行する。

### 実機テストの結果（実機テストが必要な場合）
 - コマンドを送る場合と送らない場合を比較して、なんか良くできてた
